### PR TITLE
Teach open-pr.yml about special pkgver constructs

### DIFF
--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -152,7 +152,7 @@ jobs:
             exit 0
           fi &&
 
-          update_script="$GITHUB_WORKSPACE/update-scripts/$PACKAGE_TO_UPGRADE"
+          update_script="$GITHUB_WORKSPACE/update-scripts/checksums/$PACKAGE_TO_UPGRADE"
           if test -f "$update_script"
           then
             $update_script "$UPGRADE_TO_VERSION"

--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -141,10 +141,16 @@ jobs:
         shell: bash
         run: |
           cd "/usr/src/$REPO/$PACKAGE_TO_UPGRADE" &&
-          sed -i \
-            -e "s/^\\(pkgver=\\).*/\\1$UPGRADE_TO_VERSION/" \
-            -e 's/^pkgrel=.*/pkgrel=1/' \
-            PKGBUILD &&
+          update_script="$GITHUB_WORKSPACE/version/checksums/$PACKAGE_TO_UPGRADE"
+          if test -f "$update_script"
+          then
+            $update_script "$UPGRADE_TO_VERSION"
+          else
+            sed -i \
+              -e "s/^\\(pkgver=\\).*/\\1$UPGRADE_TO_VERSION/" \
+              -e 's/^pkgrel=.*/pkgrel=1/' \
+              PKGBUILD
+          fi &&
           git update-index -q --refresh &&
           if git diff-files --exit-code
           then

--- a/update-scripts/checksums/mingw-w64-git-lfs
+++ b/update-scripts/checksums/mingw-w64-git-lfs
@@ -9,7 +9,7 @@
 (async () => {
     const version = process.argv[2]
 
-    const githubApiRequest = require('../github-api-request')
+    const githubApiRequest = require('../../github-api-request')
     const { body: releaseNotes } = await githubApiRequest(
         console,
         null,

--- a/update-scripts/version/bash
+++ b/update-scripts/version/bash
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+// The `PKGBUILD` file of `bash` is sligtly different from most other packages
+// as it sets pkgver through a _basever part and a _patchlevel part.
+
+// Therefore we need to be a bit more careful when updating than just replacing
+// the value of pkgver.
+
+(async () => {
+    const version = process.argv[2]
+
+    let [ , basever, patchlevel ] = version.match(/^(\d+\.\d+)\.(\d+)/)
+    let match
+    
+    const fs = require('fs')
+    const lines = fs.readFileSync('PKGBUILD').toString('utf-8').split(/\r?\n/)
+    lines.forEach((line, i) => {
+        if ((match = line.match(/^(\s*_basever=)\S+/))) {
+            lines[i] = `${match[1]}${basever}`
+        } else if ((match = line.match(/^(\s*_patchlevel=)\S+\s(.*)/))) {
+            lines[i] = `${match[1]}${patchlevel.toString().padStart(3, "0")} ${match[2]}`
+        } else if ((match = line.match(/^(\s*pkgrel=)\S+/))) {
+            lines[i] = `${match[1]}${1}`
+        }
+    })
+    fs.writeFileSync('PKGBUILD', lines.join('\n'))
+})().catch(console.log)


### PR DESCRIPTION
Some packages set `pkgver` in a way that doesn't quite work with our generic `sed` invocation. Teach our `open-pr` workflow to use a package specific update script for that step like we already do with the `updpkgsums` step.

This fixes #1 