### PR TITLE
build-and-deploy: fix the run-name for MSYS builds

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,5 +1,5 @@
 name: build-and-deploy
-run-name: Build${{ inputs.build_only == '' && ' and deploy' || '' }} ${{ !startsWith(inputs.package, 'mingw-w64-') && inputs.repo != 'MSYS2-packages' && inputs.package != 'git-extra' && inputs.package != 'git-for-windows-keyring' && 'mingw-w64-' || '' }}${{ inputs.package }}${{ inputs.architecture && ' (${{ inputs.architecture }})' || '' }}
+run-name: Build${{ inputs.build_only == '' && ' and deploy' || '' }} ${{ !startsWith(inputs.package, 'mingw-w64-') && inputs.repo != 'MSYS2-packages' && inputs.package != 'git-extra' && inputs.package != 'git-for-windows-keyring' && 'mingw-w64-' || '' }}${{ inputs.package }}${{ inputs.architecture && format(' ({0})', inputs.architecture) || '' }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Seems that the `${{ ... }}` construct is not recursive: embedding it within itself won't have the inner one expanded. In other words, [triggering an `i686` build of the `mintty` package resulted in this very ugly title](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/3730919260):

	Build and deploy mintty (${{ inputs.architecture }})

Let's avoid that by using [the `format()` function](https://docs.github.com/en/actions/learn-github-actions/expressions#format).