### PR TITLE
build-and-deploy: use separate check runs for each MSys architecture

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -90,7 +90,11 @@ jobs:
               process.env.OWNER,
               process.env.REPO,
               process.env.REF,
-              process.env.BUILD_ONLY ? 'build' : 'deploy',
+              `${
+                process.env.BUILD_ONLY ? 'build' : 'deploy'
+              }${
+                process.env.ARCHITECTURE ? `_${process.env.ARCHITECTURE}` : ''
+              }`,
               `Build${process.env.BUILD_ONLY ? '' : ' and deploy'} ${process.env.PACKAGE_TO_BUILD}`,
               `${process.env.BUILD_ONLY ? 'Building' : 'Deploying'} ${process.env.PACKAGE_TO_BUILD}`,
               `For details, see [this run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}}).`,


### PR DESCRIPTION
For MSys packages we start two parrallel runs of this workflows, that can succeed or fail independently from one another. We need to use two separate check runs to accurately represent their status. The corresponding change in gfw-helper-github-app is part of https://github.com/git-for-windows/gfw-helper-github-app/pull/17