### PR TITLE
`build-and-deploy`: arm64 fixes for GPG signing

### DIFF
--- a/azure-self-hosted-runners/post-deployment-script.ps1
+++ b/azure-self-hosted-runners/post-deployment-script.ps1
@@ -29,7 +29,7 @@ $GithubActionsRunnerArch = "arm64"
 $GithubActionsRunnerHash = "9409e50d9ad33d8031355ed079b8f56cf3699f35cf5d0ca51e54deed432758ef"
 $GithubActionsRunnerLabels = "self-hosted,Windows,ARM64"
 # Keep this path short to prevent Long Path issues
-$GitHubActionsRunnerPath = "C:\actions-runner"
+$GitHubActionsRunnerPath = "C:\a"
 
 # ======================
 # WINDOWS DEVELOPER MODE


### PR DESCRIPTION
As reported [here](https://github.com/git-for-windows/git-for-windows-automation/pull/4#issuecomment-1363442879), the `Get GPG key(s)` step wasn't working on arm64.

```
gpg: key 88138B9E1A9F3986: public key "Johannes Schindelin <johannes.schindelin@gmx.de>" imported
gpg: no running gpg-agent - starting '/usr/bin/gpg-agent'
gpg: waiting for the agent to come up ... (5s)
gpg: waiting for the agent to come up ... (4s)
gpg: waiting for the agent to come up ... (3s)
gpg: waiting for the agent to come up ... (2s)
gpg: can't connect to the agent: IPC connect call failed
```

After way too many (failed) attempts to fix things, I debugged by trying `gpg-agent --daemon` directly in the pipeline and found the following:

```
gpg-agent[768]: directory '/d/actions-runner/_work/git-for-windows-automation/git-for-windows-automation/home/.gnupg' created
gpg-agent[768]: directory '/d/actions-runner/_work/git-for-windows-automation/git-for-windows-automation/home/.gnupg/private-keys-v1.d' created
gpg-agent[768]: socket name '/d/actions-runner/_work/git-for-windows-automation/git-for-windows-automation/home/.gnupg/S.gpg-agent.extra' is too long
```

Doh 🤦🏼‍♂️ I changed the path of the runner from `D:\actions-runner` to `D:\a` to get below the 100-character limit. Note that GH does this too on their hosted runners, that's why it didn't fail on the x86_64 job. See e.g. [this x86_64 run](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/3752813832/jobs/6375542282#step:2:33).