### PR TITLE
open-pr: try harder to find a corresponding `component-update` ticket

### DIFF
--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -180,7 +180,7 @@ jobs:
             let body = ''
             try {
               const name = process.env.PACKAGE_TO_UPGRADE
-              const version = `${name.match(/git-lfs/) ? 'v' : ''}${process.env.UPGRADE_TO_VERSION}`
+              const version = process.env.UPGRADE_TO_VERSION
 
               if (name === 'mintty') body = `See https://github.com/mintty/mintty/releases/tag/${version} for details.`
               else if (name === 'mingw-w64-git-lfs') body = `See https://github.com/git-lfs/git-lfs/releases/tag/${version} for details.`
@@ -188,7 +188,7 @@ jobs:
 
               const terms = 'type:issue repo:git-for-windows/git state:open author:app/github-actions label:component-update'
               const { data } = await github.rest.search.issuesAndPullRequests({
-                q: `"[New ${name.replace(/^mingw-w64-/, '')} version]" ${version} in:title ${terms}`,
+                q: `"[New ${name.replace(/^mingw-w64-/, '')} version]" (${version} OR v${version}) in:title ${terms}`,
               })
               if (data.total_count) body = `${body ? `${body}\n\n` : ''}This closes ${data.items[0].html_url}`
             } catch (e) {


### PR DESCRIPTION
When opening a Pull Request, we would like to automatically close the corresponding `component-update` ticket, if there is any.

Unfortunately, it is not _quite_ trivial to search for such tickets. One frustrating aspect is that some updates have the version number prefixed with `v` while others do not. And the search on GitHub is a bit strict about that: if you search for `0.10.1`, you won't find a ticket mentioning `v0.10.1` and the opposite is also true.

We already started to special-case at least Git LFS, but it's a bit of a whack-a-mole to do that for all components we track in Git for Windows.

Let's instead search for the version in both forms: both prefixed with `v` as well as without.

This addresses
https://github.com/git-for-windows/gfw-helper-github-app/issues/18