### PR TITLE
Fix `build-and-deploy` on self-hosted ARM64 agents

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -31,7 +31,6 @@ env:
   REF: "${{ github.event.inputs.ref }}"
   ARCHITECTURE: "${{ github.event.inputs.architecture }}"
   GPG_OPTIONS: "--batch --yes --no-tty --list-options no-show-photos --verify-options no-show-photos --pinentry-mode loopback"
-  HOME: "${{ github.workspace }}\\home"
   ACTOR: "${{ github.event.inputs.actor || github.triggering_actor }}"
   CREATE_CHECK_RUN: true
 
@@ -117,6 +116,8 @@ jobs:
         run: |
           USER_NAME="${{ steps.actor.outputs.name }}" &&
           USER_EMAIL="${{ steps.actor.outputs.email }}" &&
+          HOME="${{ runner.temp }}\\home" &&
+          echo "HOME=$HOME" >>$GITHUB_ENV &&
           mkdir -p "$HOME" &&
           git config --global user.name "$USER_NAME" &&
           git config --global user.email "$USER_EMAIL" &&
@@ -204,7 +205,7 @@ jobs:
         shell: bash
         run: |
           echo '${{secrets.PRIVGPGKEY}}' | tr % '\n' | gpg $GPG_OPTIONS --import &&
-          mkdir -p home &&
+          mkdir -p "$HOME" &&
           git config --global gpg.program "/usr/src/build-extra/gnupg-with-gpgkey.sh" &&
           info="$(gpg --list-keys --with-colons "${GPGKEY%% *}" | cut -d : -f 1,10 | sed -n '/^uid/{s|uid:||p;q}')" &&
           git config --global user.name "${info% <*}" &&
@@ -220,9 +221,9 @@ jobs:
           CODESIGN_PASS: ${{secrets.CODESIGN_PASS}}
         shell: bash
         run: |
-          mkdir -p home/.sig &&
-          echo "$CODESIGN_P12" | tr % '\n' | base64 -d >home/.sig/codesign.p12 &&
-          echo "$CODESIGN_PASS" >home/.sig/codesign.pass
+          mkdir -p "$HOME"/.sig &&
+          echo "$CODESIGN_P12" | tr % '\n' | base64 -d >"$HOME"/.sig/codesign.p12 &&
+          echo "$CODESIGN_PASS" >"$HOME"/.sig/codesign.pass
           git config --global alias.signtool '!sh "/usr/src/build-extra/signtool.sh"'
           echo "SIGNTOOL=git signtool" >>$GITHUB_ENV
 
@@ -302,7 +303,7 @@ jobs:
       - name: Clean up temporary files
         if: always()
         shell: bash
-        run: rm -rf home
+        run: rm -rf "$HOME"
 
       - name: mark check run as completed
         if: env.CREATE_CHECK_RUN != 'false' && always()


### PR DESCRIPTION
The underlying problem why earlier attempts to deploy `mingw-w64-aarch64-git-extra` failed (e.g. [this one](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/3760961637)) has _nothing_ to do with ARM64 at all. The problem is that GNU Privacy Guard wants to put a socket into `~/.gnupg/` whose complete path (including NUL byte) has to fit within a mere 108 bytes.

With this proposed work-around, [the build succeeded](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/3825211124/jobs/6508034961) (I specifically only ran the _build_, not the _deploy_ part just yet, so that we can verify that the build _actually_ worked).