### PR TITLE
Prepare for building arm64 versions of the `wintoast` and `git-credential-manager` packages

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -250,6 +250,12 @@ jobs:
                     esac
           )
 
+          # No need to rebuild i686/x86_64 flavors when building the initial
+          # arm64 versions of the wintoast/GCM packages
+          test ebe6c944c573ee4d8900f0e015365468606c9e1e != "$REF" ||
+          test "mingw32 mingw64 clangarm64" != "$MINGW_ARCHS_TO_BUILD" ||
+          MINGW_ARCHS_TO_BUILD=clangarm64
+
           cd "/usr/src/$REPO/$PACKAGE_TO_BUILD" &&
           MAKEFLAGS=-j6 PKGEXT='.pkg.tar.xz' MINGW_ARCH=$MINGW_ARCHS_TO_BUILD $MAKEPKG -s --noconfirm &&
           cp *.pkg.tar* "$dir/" &&

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -241,7 +241,14 @@ jobs:
             printf '#!/bin/sh\n\nexec /mingw64/bin/git.exe "$@"\n' >/usr/bin/git
           } &&
 
-          MINGW_ARCHS_TO_BUILD=$(test "$ARCHITECTURE" == "aarch64" && echo "clangarm64" || echo "mingw32 mingw64")
+          MINGW_ARCHS_TO_BUILD=$(
+                    case "$ARCHITECTURE,$PACKAGE_TO_BUILD" in
+                    aarch64,*) echo "clangarm64";;
+                    *,mingw-w64-wintoast) echo "mingw32 mingw64 clangarm64";; # We're (cross-)compiling via Visual Studio
+                    *,mingw-w64-git-credential-manager) echo "mingw32 mingw64 clangarm64";; # We're downloading the pre-built x86 artifacts and using them for all three platforms
+                    *) echo "mingw32 mingw64";;
+                    esac
+          )
 
           cd "/usr/src/$REPO/$PACKAGE_TO_BUILD" &&
           MAKEFLAGS=-j6 PKGEXT='.pkg.tar.xz' MINGW_ARCH=$MINGW_ARCHS_TO_BUILD $MAKEPKG -s --noconfirm &&


### PR DESCRIPTION
As discussed [here](https://github.com/git-for-windows/git-sdk-arm64/issues/3#issuecomment-1371496963).