### PR TITLE
build-and-deploy: use hosted runners for git-lfs for ARM64

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -250,6 +250,7 @@ jobs:
                     aarch64,*) echo "clangarm64";;
                     *,mingw-w64-wintoast) echo "mingw32 mingw64 clangarm64";; # We're (cross-)compiling via Visual Studio
                     *,mingw-w64-git-credential-manager) echo "mingw32 mingw64 clangarm64";; # We're downloading the pre-built x86 artifacts and using them for all three platforms
+                    *,mingw-w64-git-lfs) echo "mingw32 mingw64 clangarm64";; # We're downloading the pre-built artifacts from Git LFS' official release page
                     *) echo "mingw32 mingw64";;
                     esac
           )


### PR DESCRIPTION
This is similar in spirit to #12, just for Git LFS (which I really should have included but I forgot that it was in the same boat as wintoast/Git Credential Manager).