### PR TITLE
self-hosted runner: always use latest Git for Windows and GitHub Actions version (plus some PowerShell cleanups)

### DIFF
--- a/azure-self-hosted-runners/post-deployment-script.ps1
+++ b/azure-self-hosted-runners/post-deployment-script.ps1
@@ -1,25 +1,24 @@
 param (
-    # GitHub Actions Runner registration token. Note that these tokens are only valid for one hour after creation, so we always expect the user to provide one.
     # https://docs.github.com/en/actions/hosting-your-own-runners/adding-self-hosted-runners
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $true, HelpMessage = "GitHub Actions Runner registration token. Note that these tokens are only valid for one hour after creation, so we always expect the user to provide one.")]
     [string]$GitHubActionsRunnerToken,
 
     # GitHub Actions Runner repository. E.g. "https://github.com/MY_ORG" (org-level) or "https://github.com/MY_ORG/MY_REPO" (repo-level)
     # https://docs.github.com/en/actions/hosting-your-own-runners/adding-self-hosted-runners
     [Parameter(Mandatory = $true)]
+    [ValidateScript({ $_ -notlike "https://*" })]
     [string]$GithubActionsRunnerRegistrationUrl,
 
-    # Actions Runner name. Needs to be unique in the org/repo
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $true, HelpMessage = "Name of the runner. Needs to be unique in the org/repo")]
+    [ValidateNotNullOrEmpty()]
     [string]$GithubActionsRunnerName,
 
-    # Stop Service immediately (useful for spinning up runners preemptively)
-    [Parameter(Mandatory = $false)]
+    [Parameter(Mandatory = $false, HelpMessage = "Stop Service immediately (useful for spinning up runners preemptively)")]
     [ValidateSet('true', 'false')]
     [string]$StopService = 'true',
 
-    # Path to the Actions Runner. Keep this path short to prevent Long Path issues, e.g. D:\a
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $true, HelpMessage = "Path to the Actions Runner. Keep this path short to prevent Long Path issues, e.g. D:\a")]
+    [ValidateNotNullOrEmpty()]
     [string]$GitHubActionsRunnerPath
 )
 

--- a/azure-self-hosted-runners/post-deployment-script.ps1
+++ b/azure-self-hosted-runners/post-deployment-script.ps1
@@ -59,17 +59,17 @@ try {
         }
     }
     else {
-        throw "Could not find hash for $GithubExeName"
-        break;
+        Write-Error "Could not find hash for $GithubExeName"
+        exit 1
     }
 }
 catch {
-    Write-Output @"
+    Write-Error @"
    "Message: "$($_.Exception.Message)`n
    "Error Line: "$($_.InvocationInfo.Line)`n
    "Line Number: "$($_.InvocationInfo.ScriptLineNumber)`n
 "@
-    break;
+    exit 1
 }
 
 # =================================
@@ -99,17 +99,17 @@ try {
         }
     }
     else {
-        throw "Error: Could not find hash for Github Actions Runner"
-        break;
+        Write-Error "Error: Could not find hash for Github Actions Runner"
+        exit 1
     }
 }
 catch {
-    Write-Output @"
+    Write-Error @"
    "Message: "$($_.Exception.Message)`n
    "Error Line: "$($_.InvocationInfo.Line)`n
    "Line Number: "$($_.InvocationInfo.ScriptLineNumber)`n
 "@
-    break;
+    exit 1
 }
 
 # ======================
@@ -139,8 +139,8 @@ Invoke-WebRequest -UseBasicParsing -Uri $GitHubGit.DownloadUrl -OutFile $GitHubG
 $ProgressPreference = 'Continue'
 
 if ((Get-FileHash -Path $GitHubGit.OutFile -Algorithm SHA256).Hash.ToUpper() -ne $GitHubGit.Hash) {
-    throw "Computed checksum for $($GitHubGit.OutFile) did not match $($GitHubGit.Hash)"
-    break;
+    Write-Error "Computed checksum for $($GitHubGit.OutFile) did not match $($GitHubGit.Hash)"
+    exit 1
 }
 
 Write-Output "Installing Git for Windows..."
@@ -186,8 +186,8 @@ Invoke-WebRequest -UseBasicParsing -Uri $GitHubAction.DownloadUrl -OutFile $GitH
 $ProgressPreference = 'Continue'
 
 if ((Get-FileHash -Path $GitHubAction.OutFile -Algorithm SHA256).Hash.ToUpper() -ne $GitHubAction.hash) {
-    throw "Computed checksum for $($GitHubAction.OutFile) did not match $($GitHubAction.hash)"
-    break;
+    Write-Error "Computed checksum for $($GitHubAction.OutFile) did not match $($GitHubAction.hash)"
+    exit 1
 }
 
 Write-Output "Installing GitHub Actions runner $($GitHubAction.Tag) as a Windows service with labels $($GitHubAction.RunnerLabels)..."

--- a/azure-self-hosted-runners/post-deployment-script.ps1
+++ b/azure-self-hosted-runners/post-deployment-script.ps1
@@ -6,7 +6,7 @@ param (
     # GitHub Actions Runner repository. E.g. "https://github.com/MY_ORG" (org-level) or "https://github.com/MY_ORG/MY_REPO" (repo-level)
     # https://docs.github.com/en/actions/hosting-your-own-runners/adding-self-hosted-runners
     [Parameter(Mandatory = $true)]
-    [ValidateScript({ $_ -notlike "https://*" })]
+    [ValidateScript({ $_ -like "https://*" })]
     [string]$GithubActionsRunnerRegistrationUrl,
 
     [Parameter(Mandatory = $true, HelpMessage = "Name of the runner. Needs to be unique in the org/repo")]
@@ -14,7 +14,7 @@ param (
     [string]$GithubActionsRunnerName,
 
     [Parameter(Mandatory = $false, HelpMessage = "Stop Service immediately (useful for spinning up runners preemptively)")]
-    [bool]$StopService = $true,
+    [string]$StopService = 'true',
 
     [Parameter(Mandatory = $true, HelpMessage = "Path to the Actions Runner. Keep this path short to prevent Long Path issues, e.g. D:\a")]
     [ValidateNotNullOrEmpty()]
@@ -221,7 +221,7 @@ if ($null -eq (Get-Service -Name "actions.runner.*")) {
 }
 
 # Immediately stop the service as we want to leave the VM in a deallocated state for later use. The service will automatically be started when Windows starts.
-if ($StopService -eq $true) {
+if ($StopService -eq 'true') {
     #Collects all running services named actions.runner.*
     $GetActionRunnerServices = Get-Service -Name "actions.runner.*" | Where-Object { $_.Status -eq 'Running' } | Select-Object -ExpandProperty Name
 

--- a/azure-self-hosted-runners/post-deployment-script.ps1
+++ b/azure-self-hosted-runners/post-deployment-script.ps1
@@ -14,8 +14,7 @@ param (
     [string]$GithubActionsRunnerName,
 
     [Parameter(Mandatory = $false, HelpMessage = "Stop Service immediately (useful for spinning up runners preemptively)")]
-    [ValidateSet('true', 'false')]
-    [string]$StopService = 'true',
+    [bool]$StopService = $true,
 
     [Parameter(Mandatory = $true, HelpMessage = "Path to the Actions Runner. Keep this path short to prevent Long Path issues, e.g. D:\a")]
     [ValidateNotNullOrEmpty()]
@@ -222,7 +221,7 @@ if ($null -eq (Get-Service -Name "actions.runner.*")) {
 }
 
 # Immediately stop the service as we want to leave the VM in a deallocated state for later use. The service will automatically be started when Windows starts.
-if ($StopService -eq 'true') {
+if ($StopService -eq $true) {
     #Collects all running services named actions.runner.*
     $GetActionRunnerServices = Get-Service -Name "actions.runner.*" | Where-Object { $_.Status -eq 'Running' } | Select-Object -ExpandProperty Name
 

--- a/azure-self-hosted-runners/post-deployment-script.ps1
+++ b/azure-self-hosted-runners/post-deployment-script.ps1
@@ -207,7 +207,7 @@ if ($null -eq (Get-Service -Name "actions.runner.*")) {
 
     [int]$RetryCountService = 0
     do {
-        Write-Output "Attempt $($RetryCountService): Looking for service actions.runner.*..."
+        Write-Output "Attempt $($RetryCountService) of 3: Looking for service actions.runner.*..."
         $RetryCountService++
         Start-Sleep -Seconds 3
     }
@@ -235,7 +235,7 @@ if ($StopService -eq 'true') {
         # Making sure that all of the services has been stopped before moving forward
         [int]$RetryCount = 0
         do {
-            Write-Output "Waiting for service $Service to stop..."
+            Write-Output "Attempt: $($RetryCount) of 5: Waiting for service $Service to stop..."
             $RetryCount++
             Start-Sleep -Seconds 5
         }

--- a/azure-self-hosted-runners/post-deployment-script.ps1
+++ b/azure-self-hosted-runners/post-deployment-script.ps1
@@ -14,6 +14,7 @@ param (
     [string]$GithubActionsRunnerName,
 
     [Parameter(Mandatory = $false, HelpMessage = "Stop Service immediately (useful for spinning up runners preemptively)")]
+    [ValidateSet('true', 'false')]
     [string]$StopService = 'true',
 
     [Parameter(Mandatory = $true, HelpMessage = "Path to the Actions Runner. Keep this path short to prevent Long Path issues, e.g. D:\a")]

--- a/azure-self-hosted-runners/post-deployment-script.ps1
+++ b/azure-self-hosted-runners/post-deployment-script.ps1
@@ -139,7 +139,8 @@ Invoke-WebRequest -UseBasicParsing -Uri $GitHubGit.DownloadUrl -OutFile $GitHubG
 $ProgressPreference = 'Continue'
 
 if ((Get-FileHash -Path $GitHubGit.OutFile -Algorithm SHA256).Hash.ToUpper() -ne $GitHubGit.Hash) {
-    throw 'Computed checksum did not match'
+    throw "Computed checksum for $($GitHubGit.OutFile) did not match $($GitHubGit.Hash)"
+    break;
 }
 
 Write-Output "Installing Git for Windows..."
@@ -184,7 +185,10 @@ $ProgressPreference = 'SilentlyContinue'
 Invoke-WebRequest -UseBasicParsing -Uri $GitHubAction.DownloadUrl -OutFile $GitHubAction.OutFile
 $ProgressPreference = 'Continue'
 
-if ((Get-FileHash -Path $GitHubAction.OutFile -Algorithm SHA256).Hash.ToUpper() -ne $GitHubAction.hash) { throw 'Computed checksum did not match' }
+if ((Get-FileHash -Path $GitHubAction.OutFile -Algorithm SHA256).Hash.ToUpper() -ne $GitHubAction.hash) {
+    throw "Computed checksum for $($GitHubAction.OutFile) did not match $($GitHubAction.hash)"
+    break;
+}
 
 Write-Output "Installing GitHub Actions runner $($GitHubAction.Tag) as a Windows service with labels $($GitHubAction.RunnerLabels)..."
 


### PR DESCRIPTION
**GitHub git-windows and Action runner**
- Added check as was asked for both ActionRunner and GitHub git-windows
- Now all data for GitHub git-windows and ActionRunner are stored in the objects $GitHubAction and $GitHubGit
- Used invoke-restmethod to eliminate overhead and it makes it easier to go over to PSCore later on. Also I added the accept and API version in the header. With this you don't need to convert it from json etc. it's easier.

**Ensure that Action runner service was created**
Added so it will look if it has been created 3 times 3 seconds apart before it write error as sometime it can take time for the service to be created.

**Stop Service, actions.runner.***
- As you was using * I'm guessing that it can be many services so I did add an foreach loop on them.
- Inside the foreach it will make sure that each service has been stopped before continuing, it will look 5 times with 5 seconds apart.

**Param**
- Moved text to helpmessage
- Added validation
- Changed StopService to bool so now you need to write -StopService $false if you don't want to stop the service. Default it's $true as it was from the start.

**Error handling**
- Replaced throw with write-error and exit 1 as I'm guessing that you want to exit the script on this errors.

**Other**
- Removed $ProgressPreferences where it was not needed.



Got some more things that I can do later on when I have the time, I have tested it locally at the code should work but as I can't test with ActionRunner I'm advising you to test it also.
