### PR TITLE
azure-arm-template: bump image SKU to win11-22h2

### DIFF
--- a/azure-self-hosted-runners/azure-arm-template.json
+++ b/azure-self-hosted-runners/azure-arm-template.json
@@ -204,7 +204,7 @@
                     "imageReference": {
                         "publisher": "microsoftwindowsdesktop",
                         "offer": "windows11preview-arm64",
-                        "sku": "win11-21h2-ent",
+                        "sku": "win11-22h2-ent",
                         "version": "latest"
                     }
                 },


### PR DESCRIPTION
We were using the older win11-21h2 SKU. Let's use the newer SKU instead.