### PR TITLE
open-pr: actually use version update scripts

### DIFF
--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -141,7 +141,7 @@ jobs:
         shell: bash
         run: |
           cd "/usr/src/$REPO/$PACKAGE_TO_UPGRADE" &&
-          update_script="$GITHUB_WORKSPACE/version/checksums/$PACKAGE_TO_UPGRADE"
+          update_script="$GITHUB_WORKSPACE/update-scripts/version/$PACKAGE_TO_UPGRADE"
           if test -f "$update_script"
           then
             $update_script "$UPGRADE_TO_VERSION"


### PR DESCRIPTION
when creating e60ad7c (open-pr: support update scripts to set `pkgver`, 2022-12-14) I copy-edited the wrong part of the path which lead to nonsense.