### PR TITLE
create-azure-self-hosted-runners: use unique deployment names

### DIFF
--- a/.github/workflows/create-azure-self-hosted-runners.yml
+++ b/.github/workflows/create-azure-self-hosted-runners.yml
@@ -152,6 +152,7 @@ jobs:
       id: deploy-arm-template
       with:
         resourceGroupName: ${{ secrets.AZURE_RESOURCE_GROUP }}
+        deploymentName: deploy-${{ steps.generate-vm-name.outputs.vm_name }}
         template: ./azure-self-hosted-runners/azure-arm-template.json
         parameters: ./azure-self-hosted-runners/azure-arm-template-example-parameters.json ${{ env.AZURE_ARM_PARAMETERS }}
     


### PR DESCRIPTION
When multiple parallel deployments were requested, all deployments after the first [failed](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/4116757131/attempts/1) with `Unable to edit or replace deployment 'azure-arm-template'`. Let's use unique deployment names related to the generated VM name so that we not only can support parallel deployments, but also should be able to have a better Azure deployment log history.

Ref: https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-powershell#deployment-name