### PR TITLE
open-pr: don't concatenate  after last command of a step

### DIFF
--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -117,7 +117,7 @@ jobs:
           git checkout -- &&
 
           # makepkg/updpkgsums expects `curl` to be present in `/usr/bin/`
-          printf '#!/bin/sh\n\nexec /mingw64/bin/curl.exe "$@"' >usr/bin/curl &&
+          printf '#!/bin/sh\n\nexec /mingw64/bin/curl.exe "$@"' >usr/bin/curl
       - name: use git-sdk-64 subset
         shell: bash
         run: |


### PR DESCRIPTION
We've split a step into two, but left the `&&` at the end of the first. That leads to failures like this one:

https://github.com/git-for-windows/git-for-windows-automation/actions/runs/4150668809/jobs/7180481501