### PR TITLE
Deal with expired installation access tokens

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -66,7 +66,7 @@ jobs:
             )
 
             const getInstallationAccessToken = require('./get-installation-access-token')
-            const accessToken = await getInstallationAccessToken(
+            const { token: accessToken } = await getInstallationAccessToken(
               console,
               appId,
               privateKey,

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -66,7 +66,7 @@ jobs:
             )
 
             const getInstallationAccessToken = require('./get-installation-access-token')
-            const { token: accessToken } = await getInstallationAccessToken(
+            const { expiresAt, token: accessToken } = await getInstallationAccessToken(
               console,
               appId,
               privateKey,
@@ -74,6 +74,7 @@ jobs:
             )
 
             core.setSecret(accessToken)
+            core.setOutput('expires-at', expiresAt)
             core.setOutput('token', accessToken)
 
       - name: get check run id
@@ -295,6 +296,45 @@ jobs:
             exit 1
           fi
 
+      - name: refresh installation token (if needed)
+        if: env.CREATE_CHECK_RUN != 'false'
+        id: refresh
+        uses: actions/github-script@v6
+        with:
+          script: |
+            // GitHub Apps' installation access tokens expire after one hour, see:
+            // https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#authenticating-as-an-installation
+            // let's generate a new one if less than 5 minutes before the expiry date, otherwise reuse it
+            if (Date.parse('${{ steps.setup.outputs.expires-at }}') - Date.now() > 5 * 60 * 1000) {
+              core.setOutput('expires-at', '${{ steps.setup.outputs.expires-at }}')
+              core.setOutput('token', '${{ steps.setup.outputs.token }}')
+              core.info('Continuing to use the unexpired installation access token')
+              return
+            }
+            const appId = ${{ secrets.GH_APP_ID }}
+            const privateKey = `${{ secrets.GH_APP_PRIVATE_KEY }}`
+
+            const getAppInstallationId = require('./get-app-installation-id')
+            const installationId = await getAppInstallationId(
+              console,
+              appId,
+              privateKey,
+              process.env.OWNER,
+              process.env.REPO
+            )
+
+            const getInstallationAccessToken = require('./get-installation-access-token')
+            const { expiresAt, token: accessToken } = await getInstallationAccessToken(
+              console,
+              appId,
+              privateKey,
+              installationId
+            )
+
+            core.setSecret(accessToken)
+            core.setOutput('expires-at', expiresAt)
+            core.setOutput('token', accessToken)
+
       - name: update check-run
         if: env.CREATE_CHECK_RUN != 'false'
         uses: actions/github-script@v6
@@ -303,7 +343,7 @@ jobs:
             const updateCheckRun = require('./update-check-run')
             await updateCheckRun(
               console,
-              '${{ steps.setup.outputs.token }}',
+              '${{ steps.refresh.outputs.token }}',
               process.env.OWNER,
               process.env.REPO,
               '${{ steps.check-run.outputs.id }}',
@@ -347,7 +387,7 @@ jobs:
             const updateCheckRun = require('./update-check-run')
             await updateCheckRun(
               console,
-              '${{ steps.setup.outputs.token }}',
+              '${{ steps.refresh.outputs.token }}',
               process.env.OWNER,
               process.env.REPO,
               '${{ steps.check-run.outputs.id }}',

--- a/.github/workflows/create-azure-self-hosted-runners.yml
+++ b/.github/workflows/create-azure-self-hosted-runners.yml
@@ -80,7 +80,7 @@ jobs:
           )
 
           const getInstallationAccessToken = require('./get-installation-access-token')
-          const accessToken = await getInstallationAccessToken(
+          const { token: accessToken } = await getInstallationAccessToken(
             console,
             appId,
             privateKey,

--- a/get-installation-access-token.js
+++ b/get-installation-access-token.js
@@ -7,6 +7,8 @@ module.exports = async (context, appId, privateKey, installation_id) => {
         'POST',
         `/app/installations/${installation_id}/access_tokens`)
     if (answer.error) throw answer.error
-    if (answer.token) return answer.token
+    if (answer.token) return {
+        token: answer.token
+    }
     throw new Error(`Unhandled response:\n${JSON.stringify(answer, null, 2)}`)
 }

--- a/get-installation-access-token.js
+++ b/get-installation-access-token.js
@@ -8,6 +8,7 @@ module.exports = async (context, appId, privateKey, installation_id) => {
         `/app/installations/${installation_id}/access_tokens`)
     if (answer.error) throw answer.error
     if (answer.token) return {
+        expiresAt: answer.expires_at,
         token: answer.token
     }
     throw new Error(`Unhandled response:\n${JSON.stringify(answer, null, 2)}`)


### PR DESCRIPTION
GitHub Apps' installation access tokens expire after an hour.

That is the reason why the [`mingw-w64-gnutls`](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/4153007326/jobs/7184357891) and the [`mingw-w64-gnutls(aarch64)`](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/4153007483/jobs/7184358147) builds failed: it took more than an hour to build those Pacman packages.

Work around such issues by refreshing the installation access token if needed.

[Here](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/4161550580/jobs/7199654542#step:6:50) is a workflow run demonstrating (via essentially a dry-run) that the non-expiring case [still works as expected](https://github.com/git-for-windows/git-for-windows-automation/runs/11293445146), and [here](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/4161537885/jobs/7199628037#step:6:55) is a workflow run where an expired token was simulated, and it [still managed to update the check run](https://github.com/git-for-windows/git-for-windows-automation/runs/11293409305).