### PR TITLE
open-pr: getInstallationAccessToken returns a struct

### DIFF
--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -65,7 +65,7 @@ jobs:
             )
 
             const getInstallationAccessToken = require('./get-installation-access-token')
-            const accessToken = await getInstallationAccessToken(
+            const { token: accessToken } = await getInstallationAccessToken(
               console,
               appId,
               privateKey,


### PR DESCRIPTION
getInstallationAccessToken was recently changed to return more information about the access token. We updated most callers, but missed this one.