### PR TITLE
build-and deploy: refresh token, even on failure

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -297,7 +297,7 @@ jobs:
           fi
 
       - name: refresh installation token (if needed)
-        if: env.CREATE_CHECK_RUN != 'false'
+        if: env.CREATE_CHECK_RUN != 'false' && always()
         id: refresh
         uses: actions/github-script@v6
         with:


### PR DESCRIPTION
the "mark check run as completed" step depends the token output of this step.

This fixes https://github.com/git-for-windows/git-for-windows-automation/issues/36