### PR TITLE
Fix pushing `MINGW-packages` updates in the `release-git` workflow

### DIFF
--- a/repository-updates.js
+++ b/repository-updates.js
@@ -20,6 +20,33 @@ const getWorkflowRunArtifact = async (context, token, owner, repo, workflowRunId
   await downloadAndUnZip(token, urls[name], name)
 }
 
+const mergeBundle = (gitDir, worktree, bundlePath, refName) => {
+  callGit(['--git-dir', gitDir, 'fetch', bundlePath, refName])
+  // If there is nothing to merge, return early
+  if (callGit(['--git-dir', gitDir, 'rev-list', '--count', `${refName}..FETCH_HEAD`]) === '0') return
+
+  if (worktree) {
+    callGit(['branch', '-M', refName], worktree)
+    callGit(['merge', '--no-edit', 'FETCH_HEAD'], worktree)
+  } else {
+    // If it fast-forwards, we do not need a worktree
+    if (callGit(['--git-dir', gitDir, 'rev-list', '--count', `FETCH_HEAD..${refName}`]) === '0') {
+      callGit(['--git-dir', gitDir, 'update-ref', `refs/heads/${refName}`, 'FETCH_HEAD'])
+    } else {
+      // Fine. We need a worktree. But we don't have one. So let's create one.
+      worktree = `${gitDir}/tmp-worktree`
+      callGit(['--git-dir', gitDir, 'worktree', 'add', '--no-checkout', worktree])
+      // No need for a full checkout, it's not as if we want to resolve any merge conflicts...
+      callGit(['sparse-checkout', 'set'], worktree)
+      callGit(['switch', '-d', refName], worktree)
+      // Perform the merge
+      callGit(['fetch', bundlePath, refName], worktree)
+      callGit(['merge', '--no-edit', 'FETCH_HEAD'], worktree)
+      callGit(['update-ref', `refs/heads/${refName}`, 'HEAD'], worktree)
+    }
+  }
+}
+
 const pushRepositoryUpdate = async (context, setSecret, appId, privateKey, owner, repo, refName, bundlePath) => {
   context.log(`Pushing updates to ${owner}/${repo}`)
 
@@ -31,13 +58,9 @@ const pushRepositoryUpdate = async (context, setSecret, appId, privateKey, owner
     `https://github.com/${owner}/${repo}`, repo
   ])
 
-  if (bundlePath) {
-    callGit(['--git-dir', gitDir, 'fetch', bundlePath, refName])
-  }
+  if (bundlePath) mergeBundle(gitDir, !bare && repo, bundlePath, refName)
 
   if (repo === 'build-extra') {
-    callGit(['branch', '-M', refName], repo)
-    callGit(['merge', '--no-edit', 'FETCH_HEAD'], repo)
     callProg('./download-stats.sh', ['--update'], repo)
     callGit(['commit', '-s', '-m', 'download-stats: new Git for Windows version', './download-stats.sh'], repo)
   } else if (repo === 'git-for-windows.github.io') {
@@ -74,6 +97,7 @@ const pushRepositoryUpdate = async (context, setSecret, appId, privateKey, owner
 }
 
 module.exports = {
+  mergeBundle,
   callGit,
   getWorkflowRunArtifact,
   pushRepositoryUpdate

--- a/repository-updates.js
+++ b/repository-updates.js
@@ -6,7 +6,7 @@ const callProg = (prog, parameters, cwd) => {
   })
   if (child.error) throw error
   if (child.status !== 0) throw new Error(`${prog} ${parameters.join(' ')} failed with status ${child.status}`)
-  return child.stdout.toString('utf-8')
+  return child.stdout.toString('utf-8').replace(/\r?\n$/, '')
 }
 
 const callGit = (parameters, cwd) => {


### PR DESCRIPTION
While the `release-git` workflow run looked as if it performed all the repository updates as expected, it actually only fetched from the `MINGW-packages.bundle` but did not merge the change. As a consequence, the `git push` had no updates to offer.

I fixed that by manually downloading the bundle in [the `git-artifacts (x86_64)` run](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/4413112845#artifacts)'s `pkg-x86_64` artifact and pushing https://github.com/git-for-windows/MINGW-packages/commit/13a189253e9fef04e18fdbd51254930905c3b9b1.

However, it is a better idea to fix this in the `release-git` workflow than to do that manual fix-up for every release.