### PR TITLE
release-git: update the `release` branch if necessary

### DIFF
--- a/.github/workflows/release-git.yml
+++ b/.github/workflows/release-git.yml
@@ -40,7 +40,20 @@ jobs:
             })
 
             if (sha !== '${{ github.sha }}') {
-              throw new Error(`The 'release' branch is not up to date!
+              // Try to update the `release` branch by fast-forwarding to `main`
+              try {
+                const { pushGitBranch } = require('./repository-updates.js')
+                await pushGitBranch(
+                  console,
+                  core.setSecret,
+                  ${{ secrets.GH_APP_ID }}
+                  ${{ toJSON(secrets.GH_APP_PRIVATE_KEY) }},
+                  context.repo.owner,
+                  context.repo.repo,
+                  'refs/heads/main:refs/heads/release'
+                )
+              } catch(e) {
+                throw new Error(`The 'release' branch is not up to date!
 
             Actual: ${sha}, expected: ${{ github.sha }}.
 
@@ -49,6 +62,7 @@ jobs:
             the 'release' branch, to allow modifying them and re-starting failed jobs
             individually. To that end, the 'release' branch is expected to point at the
             same commit as the 'main' branch when this workflow is started.`)
+              }
             }
       - uses: actions/checkout@v3
       - name: Get bundle-artifacts and sha256sums

--- a/repository-updates.js
+++ b/repository-updates.js
@@ -47,6 +47,30 @@ const mergeBundle = (gitDir, worktree, bundlePath, refName) => {
   }
 }
 
+const getPushAuthorizationHeader = async (context, setSecret, appId, privateKey, owner, repo) => {
+  const getAppInstallationId = require('./get-app-installation-id')
+  const installationId = await getAppInstallationId(
+    context,
+    appId,
+    privateKey,
+    owner,
+    repo
+  )
+
+  const getInstallationAccessToken = require('./get-installation-access-token')
+  const { token: accessToken } = await getInstallationAccessToken(
+    context,
+    appId,
+    privateKey,
+    installationId
+  )
+
+  const auth = Buffer.from(`PAT:${accessToken}`).toString('base64')
+  if (setSecret) setSecret(auth)
+
+  return `Authorization: Basic ${auth}`
+}
+
 const pushRepositoryUpdate = async (context, setSecret, appId, privateKey, owner, repo, refName, bundlePath) => {
   context.log(`Pushing updates to ${owner}/${repo}`)
 
@@ -69,31 +93,13 @@ const pushRepositoryUpdate = async (context, setSecret, appId, privateKey, owner
     callGit(['commit', '-a', '-s', '-m', 'New Git for Windows version'], repo)
   }
 
-  const getAppInstallationId = require('./get-app-installation-id')
-  const installationId = await getAppInstallationId(
-    context,
-    appId,
-    privateKey,
-    owner,
-    repo
-  )
-
-  const getInstallationAccessToken = require('./get-installation-access-token')
-  const { token: accessToken } = await getInstallationAccessToken(
-    context,
-    appId,
-    privateKey,
-    installationId
-  )
-
-  const auth = Buffer.from(`PAT:${accessToken}`).toString('base64')
-  if (setSecret) setSecret(auth)
-
+  const authorizationHeader = await getPushAuthorizationHeader(context, setSecret, appId, privateKey, owner, repo)
   callGit(['--git-dir', gitDir,
-    '-c', `http.extraHeader=Authorization: Basic ${auth}`,
+    '-c', `http.extraHeader=${authorizationHeader}`,
     'push', `https://github.com/${owner}/${repo}`, refName
   ])
   context.log(`Done pushing ref ${refName} to ${owner}/${repo}`)
+}
 }
 
 module.exports = {

--- a/repository-updates.js
+++ b/repository-updates.js
@@ -100,11 +100,28 @@ const pushRepositoryUpdate = async (context, setSecret, appId, privateKey, owner
   ])
   context.log(`Done pushing ref ${refName} to ${owner}/${repo}`)
 }
+
+const pushGitBranch = async (context, setSecret, appId, privateKey, owner, repo, pushRefSpec) => {
+  context.log(`Pushing ${pushRefSpec} to ${owner}/${repo}`)
+
+  callGit(['clone', '--bare', '--filter=blob:none',
+    '--single-branch', '--branch', 'main', '--depth', '50',
+    `https://github.com/${owner}/${repo}`, repo
+  ])
+
+  const authorizationHeader = await getPushAuthorizationHeader(context, setSecret, appId, privateKey, owner, repo)
+
+  callGit(['--git-dir', repo,
+    '-c', `http.extraHeader=${authorizationHeader}`,
+    'push', `https://github.com/${owner}/${repo}`, pushRefSpec
+  ])
+  context.log(`Done pushing ref ${pushRefSpec} to ${owner}/${repo}`)
 }
 
 module.exports = {
   mergeBundle,
   callGit,
   getWorkflowRunArtifact,
-  pushRepositoryUpdate
+  pushRepositoryUpdate,
+  pushGitBranch
 }


### PR DESCRIPTION
We already have a check to verify that the `release` branch is up to date with the `main` branch before even starting the `release-git` workflow run for real.

But we can do better than telling the user when the branch is not up to date: We can easily try to update it in the workflow run ;-)