### PR TITLE
open-pr/build-and-deploy: avoid re-deploying existing package versions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -112,6 +112,11 @@ jobs:
           git -C /usr/src/${{ env.REPO }} fetch --depth 1 origin $REF &&
           git -C /usr/src/${{ env.REPO }} reset --hard FETCH_HEAD
 
+      - name: check if the package was already deployed
+        shell: bash
+        run: |
+          ./update-scripts/ensure-not-yet-deployed.sh${{ env.ARCHITECTURE != '' && format(' --architecture={0}', env.ARCHITECTURE) || '' }} "/usr/src/$REPO/$PACKAGE_TO_BUILD"
+
       - name: Clone build-extra (unless cloned already)
         if: env.REPO != 'build-extra'
         shell: bash

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -107,10 +107,10 @@ jobs:
         shell: bash
         run: |
           mkdir -p /usr/src &&
-          git init -b main /usr/src/${{ env.REPO }} &&
-          git -C /usr/src/${{ env.REPO }} remote add origin "https://github.com/$OWNER/$REPO" &&
-          git -C /usr/src/${{ env.REPO }} fetch --depth 1 origin $REF &&
-          git -C /usr/src/${{ env.REPO }} reset --hard FETCH_HEAD
+          git init -b main /usr/src/$REPO &&
+          git -C /usr/src/$REPO remote add origin "https://github.com/$OWNER/$REPO" &&
+          git -C /usr/src/$REPO fetch --depth 1 origin $REF &&
+          git -C /usr/src/$REPO reset --hard FETCH_HEAD
 
       - name: check if the package was already deployed
         shell: bash

--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -199,6 +199,10 @@ jobs:
           git commit -sm "$msg" PKGBUILD &&
           echo "msg=$msg" >>$GITHUB_OUTPUT &&
           echo "modified=true" >>$GITHUB_OUTPUT
+      - name: check if the package was already deployed
+        shell: bash
+        run: |
+          ./update-scripts/ensure-not-yet-deployed.sh "/usr/src/$REPO/$PACKAGE_TO_UPGRADE"
       - name: push
         if: steps.update.outputs.modified == 'true'
         shell: bash

--- a/update-scripts/ensure-not-yet-deployed.sh
+++ b/update-scripts/ensure-not-yet-deployed.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+die () {
+	echo "$*" >&2
+	exit 1
+}
+
+set -x
+architecture=
+while case "$1" in
+--architecture=*)
+	architecture=${1#*=}
+	if test aarch64 = "$architecture"
+	then
+		MINGW_PACKAGE_PREFIX=mingw-w64-clang-aarch64
+	else
+		MINGW_PACKAGE_PREFIX=mingw-w64-$architecture
+	fi
+	;;
+-*) die "Unhandled option: '$1'";;
+*) break;
+esac; do shift; done
+
+test $# = 1 ||
+die "Usage: $0 <directory-containing-PKGBUILD>"
+
+cd "$1" ||
+die "Could not switch to '$1'"
+
+. ./PKGBUILD ||
+die "No/invalid PKGBUILD in '$1'?"
+
+# Via `. PKGBUILD`, the `$arch` variable is set. For MINGW packages, it must be
+# `any` (so that e.g. i686 packages can be installed into an x86_64 setup), but
+# for MSYS packages, the variable's value is a Bash array, and `$arch` refers to
+# the first array item (typically `i686`).
+#
+# We want to use `$arch` below to construct the exact file name of the package,
+# and therefore need to be careful when `--architecture` specifies an
+# architecture other than the first item of the `$arch` array: The i686 variant
+# of the package might already have deployed successfully while the x86_64
+# variant might not have, and we do _not_ want this script to prevent the latter
+# from being deployed.
+#
+# To that end, if `--architecture` was specified _and_ if `$arch` isn't `any`,
+# let's assume that `$arch` refers to a Bash array and override it to refer to
+# the intended architecture.
+
+case "$arch,$architecture" in
+any,*|*,) ;;
+*) arch="$architecture";;
+esac &&
+
+# Git for Windows' Pacman repository offers the packages in subdirectories that
+# correspond to the architecture. For i686/x86_64 MINGW packages (i.e. when
+# `--architecture` specifies an empty value), we assume that this script is run
+# in an x86_64 setup and therefore use that subdirectory.
+#
+# Note: The Pacman repository is hosted in an Azure Blobs container where
+# directory names cannot contain underscores, hence we needed to replace that
+# character with a dash.
+
+subdir="${architecture:-$arch}" &&
+case "$subdir" in
+any|x86_64) subdir=x86-64;;
+esac &&
+
+case "$pkgname" in
+git-extra)
+	pkgname="$MINGW_PACKAGE_PREFIX-$pkgname"
+	arch=any
+esac &&
+
+# See whether the package file was already uploaded to Git for Windows' Pacman
+# repository. Error out if it was.
+
+file="$pkgname-${epoch:+$epoch~}$pkgver-$pkgrel-$arch.pkg.tar.xz" &&
+url="https://wingit.blob.core.windows.net/$subdir/$file" &&
+echo "Looking at URL '$url'" >&2 &&
+if curl -sfI "$url"
+then
+	die "Already deployed: '$file'"
+fi &&
+echo "$file not yet deployed, as expected" >&2


### PR DESCRIPTION
This PR adds a sanity check that aborts early if we're about to deploy a package version that has _already_ been deployed.

This fixes https://github.com/git-for-windows/git-for-windows-automation/issues/15