### PR TITLE
Do commit `package-versions.txt` files in the `release-git` workflow

### DIFF
--- a/.github/actions/repository-updates/action.yml
+++ b/.github/actions/repository-updates/action.yml
@@ -64,6 +64,8 @@ runs:
         script: |
           const [ artifactsOwner, artifactsRepo ] = '${{ inputs.artifacts-repository }}'.split('/')
           const { getWorkflowRunArtifact, pushRepositoryUpdate } = require('./repository-updates')
+
+          // For MINGW-packages.bundle
           await getWorkflowRunArtifact(
             console,
             ${{ toJSON(inputs.artifacts-token) }},

--- a/.github/actions/repository-updates/action.yml
+++ b/.github/actions/repository-updates/action.yml
@@ -86,6 +86,26 @@ runs:
             'pkg-x86_64/MINGW-packages.bundle'
           )
 
+          // For versions/package-versions-$ver.txt
+          await getWorkflowRunArtifact(
+            console,
+            ${{ toJSON(inputs.artifacts-token) }},
+            artifactsOwner,
+            artifactsRepo,
+            ${{ inputs.git_artifacts_x86_64_workflow_run_id }},
+            'installer-x86_64'
+          )
+
+          // For versions/package-versions-$ver-MinGit.txt
+          await getWorkflowRunArtifact(
+            console,
+            ${{ toJSON(inputs.artifacts-token) }},
+            artifactsOwner,
+            artifactsRepo,
+            ${{ inputs.git_artifacts_x86_64_workflow_run_id }},
+            'mingit-x86_64'
+          )
+
           await pushRepositoryUpdate(
             console,
             core.setSecret,

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -438,7 +438,7 @@ jobs:
           echo "sha256sum-${{ matrix.artifact.name}}<<EOF" >>$GITHUB_OUTPUT &&
           cat artifacts/sha256sums.txt >>$GITHUB_OUTPUT &&
           echo EOF >>$GITHUB_OUTPUT
-      - name: Copy package-versions and pdbs
+      - name: Copy package-versions and pdbs (installer)
         if: matrix.artifact.name == 'installer'
         run: |
           cp /usr/src/build-extra/installer/package-versions.txt artifacts/ &&
@@ -448,6 +448,10 @@ jobs:
           mkdir -p cached-source-packages &&
           cp "$p"/*-pdb* cached-source-packages/ &&
           GIT_CONFIG_PARAMETERS="'windows.sdk${{env.SDK_REPO_ARCH}}.path='" ./please.sh bundle_pdbs --arch=${{env.ARCHITECTURE}} --directory="$a" installer/package-versions.txt)
+      - name: Copy package-versions (MinGit)
+        if: matrix.artifact.name == 'mingit'
+        run: |
+          cp /usr/src/build-extra/mingit/root/etc/package-versions.txt artifacts/
       - name: Publish ${{matrix.artifact.name}}-${{env.ARCHITECTURE}}
         uses: actions/upload-artifact@v3
         with:

--- a/repository-updates.js
+++ b/repository-updates.js
@@ -50,6 +50,7 @@ const mergeBundle = (gitDir, worktree, bundlePath, refName) => {
 const pushRepositoryUpdate = async (context, setSecret, appId, privateKey, owner, repo, refName, bundlePath) => {
   context.log(`Pushing updates to ${owner}/${repo}`)
 
+  // Updates to `build-extra` and `git-for-windows.github.io` need a worktree
   const bare = ['build-extra', 'git-for-windows.github.io'].includes(repo) ? '' : ['--bare']
   const gitDir = `${repo}${bare ? '' : '/.git'}`
 

--- a/repository-updates.js
+++ b/repository-updates.js
@@ -61,7 +61,7 @@ const pushRepositoryUpdate = async (context, setSecret, appId, privateKey, owner
   if (bundlePath) mergeBundle(gitDir, !bare && repo, bundlePath, refName)
 
   if (repo === 'build-extra') {
-    callProg('./download-stats.sh', ['--update'], repo)
+    callProg('sh', ['./download-stats.sh', '--update'], repo)
     callGit(['commit', '-s', '-m', 'download-stats: new Git for Windows version', './download-stats.sh'], repo)
   } else if (repo === 'git-for-windows.github.io') {
     callGit(['switch', '-C', 'main', 'origin/main'], repo)

--- a/repository-updates.js
+++ b/repository-updates.js
@@ -4,7 +4,7 @@ const callProg = (prog, parameters, cwd) => {
     stdio: ['ignore', 'pipe', 'inherit'],
     cwd
   })
-  if (child.error) throw error
+  if (child.error) throw child.error
   if (child.status !== 0) throw new Error(`${prog} ${parameters.join(' ')} failed with status ${child.status}`)
   return child.stdout.toString('utf-8').replace(/\r?\n$/, '')
 }

--- a/repository-updates.js
+++ b/repository-updates.js
@@ -62,6 +62,31 @@ const pushRepositoryUpdate = async (context, setSecret, appId, privateKey, owner
   if (bundlePath) mergeBundle(gitDir, !bare && repo, bundlePath, refName)
 
   if (repo === 'build-extra') {
+    // Add `versions/package-versions-$ver*.txt`
+    const fs = require('fs')
+    const ver = fs.readFileSync('bundle-artifacts/ver').toString().trim()
+    fs.renameSync(
+      'installer-x86_64/package-versions.txt',
+      `${repo}/versions/package-versions-${ver}.txt`
+    )
+    fs.renameSync(
+      'mingit-x86_64/package-versions.txt',
+      `${repo}/versions/package-versions-${ver}-MinGit.txt`
+    )
+    callGit([
+      'add',
+      `versions/package-versions-${ver}.txt`,
+      `versions/package-versions-${ver}-MinGit.txt`
+    ], repo)
+    callGit([
+      'commit',
+      '-s',
+      '-m', `versions: add v${ver}`,
+      `versions/package-versions-${ver}.txt`,
+      `versions/package-versions-${ver}-MinGit.txt`
+    ], repo)
+
+    // Update `download-stats.sh`
     callProg('sh', ['./download-stats.sh', '--update'], repo)
     callGit(['commit', '-s', '-m', 'download-stats: new Git for Windows version', './download-stats.sh'], repo)
   } else if (repo === 'git-for-windows.github.io') {


### PR DESCRIPTION
The `build-extra` repository has a `versions/` subdirectory in which all of the Git for Windows versions' package versions are tracked. This is supposed to happen automatically in the release automation.

However, when I ported the release automation from the Azure Release Pipeline to a GitHub workflow, I simply missed that part, so it was not done for v2.40.0 (I fixed that manually in the meantime). Here is a PR to fix that for the next time.

Note: this PR conflicts with https://github.com/git-for-windows/git-for-windows-automation/pull/42 and will need to be rebased after that PR is merged.