### PR TITLE
Fixes for check run updates

### DIFF
--- a/.github/actions/check-run-action/action.yml
+++ b/.github/actions/check-run-action/action.yml
@@ -9,17 +9,13 @@ inputs:
     required: true
   owner:
     description: 'The owner of the target repository'
-    required: true
     default: 'git-for-windows'
   repo:
     description: 'The name of the target repository'
-    required: true
   rev:
     description: 'The target commit'
-    required: true
   check-run-name:
     description: 'The name of the Check Run'
-    required: true
   title:
     description: 'The title of the Check Run'
   summary:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -70,7 +70,7 @@ jobs:
             const githubApiRequest = require('./github-api-request')
             const answer = await githubApiRequest(
               console,
-              '${{ steps.setup.outputs.token }}',
+              '${{ secrets.GITHUB_TOKEN }}',
               'GET',
               `/users/${process.env.ACTOR}`
             )

--- a/.github/workflows/tag-git.yml
+++ b/.github/workflows/tag-git.yml
@@ -26,6 +26,7 @@ env:
   REPO: "${{github.event.inputs.repo}}"
   REV: "${{github.event.inputs.rev}}"
   SNAPSHOT: "${{github.event.inputs.snapshot}}"
+  CREATE_CHECK_RUN: "true"
   NODEJS_VERSION: 16
 
 jobs:

--- a/.github/workflows/tag-git.yml
+++ b/.github/workflows/tag-git.yml
@@ -18,7 +18,7 @@ on:
       snapshot:
         description: 'A flag indicating whether this is a snapshot or a full Git for Windows release'
         required: true
-        default: true
+        default: "true"
 
 env:
   GPG_OPTIONS: "--batch --yes --no-tty --list-options no-show-photos --verify-options no-show-photos --pinentry-mode loopback"


### PR DESCRIPTION
The [latest `git-artifacts` run failed](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/5001089177) because the installation token was created more than 10 minutes before the `portable` and the `nuget` jobs were actually started (they were queued for a long time because of some concurrent workflow runs using up the contingent of hosted runners available to the Git for Windows project).

This uncovered the fact that we fail to re-generate new installation tokens because the Action lacks the proper information: it needs a repository to work with, but that information was not passed as parameter.

This is a wide-spread issue: the `check-run-action` actually requires the owner/repo information in case a new installation token needs to be generated.

This PR fixes all of those instances, and while in the space also ties up a few other loose ends.