### PR TITLE
release-git: handle missing `release` branch gracefully

### DIFF
--- a/.github/workflows/release-git.yml
+++ b/.github/workflows/release-git.yml
@@ -34,11 +34,19 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const { data: { object: { sha } } } = await github.rest.git.getRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'heads/release'
-            })
+            const sha = await (async () => {
+              try {
+                return (await github.rest.git.getRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: 'heads/release'
+                })).data.object.sha
+              } catch (e) {
+                // If the ref does not exist, use an undefined `sha`
+                if (e?.status === 404) return undefined
+                throw e
+              }
+            })()
 
             if (sha !== '${{ github.sha }}') {
               console.log(`Trying to update the 'release' branch by fast-forwarding to 'main' in ${context.repo.owner}/${context.repo.repo}`)


### PR DESCRIPTION
We already have code to fast-forward a `release` branch that is not up to date.

By mistake, I _deleted_ the `release` branch, however: the repository settings are such that merging a PR deletes its "head" branch, and I had merged the `release` branch into the `main` branch. Deleting the branch [broke the logic to fast-forward `release`](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/5028408563/jobs/9019086520#step:3:50).

Let's handle missing `release` branches the same as out-of-date branches, and try to push the current `main` to the `release` branch.