### PR TITLE
open-pr: support Clang

### DIFF
--- a/update-scripts/version/mingw-w64-clang
+++ b/update-scripts/version/mingw-w64-clang
@@ -1,0 +1,2 @@
+#!/bin/bash
+. ./update-clang-from-msys2.sh


### PR DESCRIPTION
We want to build our own smaller Clang for ARM64, teach open-pr how to update it. This update script uses the update-clang-from-msys2.sh script from https://github.com/git-for-windows/MINGW-packages/pull/75