### PR TITLE
/release: explicitly mark full versions as the latest GitHub Release

### DIFF
--- a/.github/actions/github-release/action.yml
+++ b/.github/actions/github-release/action.yml
@@ -138,6 +138,7 @@ runs:
           await state.refreshToken()
 
           console.log('Publishing release')
+          const isPrerelease = '${{ inputs.tag-name }}'.indexOf('-rc') > 0
           await updateRelease(
             console,
             state.accessToken,
@@ -145,7 +146,8 @@ runs:
             '${{ inputs.repo }}',
             release.id, {
               draft: false,
-              prerelease: '${{ inputs.tag-name }}'.indexOf('-rc') > 0
+              prerelease: isPrerelease,
+              make_latest : !isPrerelease
             }
           )
     - name: update check-run


### PR DESCRIPTION
According to the [REST API documentation of `create-a-release`](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release), the `make_latest` should default to `true`.

However, when releasing Git for Windows v2.42.0 this was not so. I had to mark it as "latest" manually, and I only realized this because the `gitforwindows.org` update would fail (because it would still pick up v2.41.0(3) as the latest release).

Let's just make it explicit that we want to mark it as the latest version (at least as long as we're not publishing a pre-release).