### PR TITLE
git-artifacts: be more patient while waiting for `tag-git` to finish

### DIFF
--- a/workflow-runs.js
+++ b/workflow-runs.js
@@ -20,8 +20,8 @@ const waitForWorkflowRunToFinish = async (context, token, owner, repo, workflowR
           return res
       }
       if (context.log) context.log(`Waiting for workflow run ${workflowRunId} (current status: ${res.status})`)
-      if (counter++ > 30) throw new Error(`Times out waiting for workflow run ${workflowRunId}?`)
-      await sleep(1000)
+      if (counter++ > 60) throw new Error(`Times out waiting for workflow run ${workflowRunId}?`)
+      await sleep(10000)
   }
 }
 


### PR DESCRIPTION
It is important for the `git-artifacts` job to wait for the `tag-git` job to finish because it requires the latter's build artifacts, yet it is started before the latter actually finishes.

However, polling every second, up to 30 times, is way too impatient. There are sometimes glitches that make `tag-git` take longer to spin down, and we don't want the `git-artifacts` job to fail because of that. Yet this is what actually happened today, when I tried to take care of Git for Windows v2.43.0-rc1: [x86_64 run](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/6802867432/job/18496910525#step:4:62) and [i686 run](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/6802867977/job/18496912295#step:4:62).

Let's just look only every 10 seconds, it does not make much difference to the overall run time, and for good measure let's wait up to ~10 minutes.