### PR TITLE
`/git-artifacts`: reset `pkgrel=1` between releases

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -287,7 +287,7 @@ jobs:
           printf '#!/bin/sh\n\nexec '$MINGW_PREFIX'/bin/git.exe "$@"\n' >/usr/bin/git &&
           (
             cd /usr/src/MINGW-packages/mingw-w64-git/src/git &&
-            /usr/src/build-extra/please.sh build-mingw-w64-git --only-$ARCHITECTURE $BUILD_SRC \
+            /usr/src/build-extra/please.sh build-mingw-w64-git --reset-pkgrel --only-$ARCHITECTURE $BUILD_SRC \
               -o "$GITHUB_WORKSPACE"/artifacts HEAD
           ) &&
           cp bundle-artifacts/ver artifacts/ &&


### PR DESCRIPTION
As @rimrul noticed, between v2.43.0-rc1 and v2.43.0-rc2 we [did not reset `pkgrel=1`](https://github.com/git-for-windows/git/pull/4692#issuecomment-1817775282).

This is part 2 (The Conclusion) of the two-parter to address this (and I plan on merging this today, [in time for v2.43.0 final](https://gh.io/gitCal)) and requires https://github.com/git-for-windows/build-extra/pull/534 to be merged first (hence it is opened as draft PR to avoid merging it accidentally before that other PR).