### PR TITLE
Self hosted runner: update image and make configurable through env vars

### DIFF
--- a/.github/workflows/create-azure-self-hosted-runners.yml
+++ b/.github/workflows/create-azure-self-hosted-runners.yml
@@ -39,6 +39,7 @@ env:
   # For more information, see https://learn.microsoft.com/en-us/azure/virtual-machines/dplsv5-dpldsv5-series (which
   # unfortunately does not have more information about price by region)
   AZURE_VM_REGION: westus2
+  AZURE_VM_IMAGE: win11-22h2-ent
 
 # The following secrets are required for this workflow to run:
 # AZURE_CREDENTIALS - Credentials for the Azure CLI. It's recommended to set up a resource
@@ -130,6 +131,7 @@ jobs:
           githubActionsRunnerRegistrationUrl="$ACTIONS_RUNNER_REGISTRATION_URL"
           githubActionsRunnerToken="$ACTIONS_RUNNER_TOKEN"
           postDeploymentPsScriptUrl="$POST_DEPLOYMENT_SCRIPT_URL"
+          virtualMachineImage="$AZURE_VM_IMAGE"
           virtualMachineName="${{ steps.generate-vm-name.outputs.vm_name }}"
           virtualMachineSize="$AZURE_VM_TYPE"
           publicIpAddressName1="${{ steps.generate-vm-name.outputs.vm_name }}-ip"

--- a/.github/workflows/create-azure-self-hosted-runners.yml
+++ b/.github/workflows/create-azure-self-hosted-runners.yml
@@ -39,7 +39,7 @@ env:
   # For more information, see https://learn.microsoft.com/en-us/azure/virtual-machines/dplsv5-dpldsv5-series (which
   # unfortunately does not have more information about price by region)
   AZURE_VM_REGION: westus2
-  AZURE_VM_IMAGE: win11-22h2-ent
+  AZURE_VM_IMAGE: win11-23h2-ent
 
 # The following secrets are required for this workflow to run:
 # AZURE_CREDENTIALS - Credentials for the Azure CLI. It's recommended to set up a resource

--- a/azure-self-hosted-runners/azure-arm-template.json
+++ b/azure-self-hosted-runners/azure-arm-template.json
@@ -81,6 +81,9 @@
         "osDiskDeleteOption": {
             "type": "string"
         },
+        "virtualMachineImage": {
+            "type": "string"
+        },
         "virtualMachineSize": {
             "type": "string"
         },
@@ -209,7 +212,7 @@
                     "imageReference": {
                         "publisher": "microsoftwindowsdesktop",
                         "offer": "windows11preview-arm64",
-                        "sku": "win11-22h2-ent",
+                        "sku": "[parameters('virtualMachineImage')]",
                         "version": "latest"
                     }
                 },


### PR DESCRIPTION
Updates the self hosted runner image and also makes it configurable through env vars.

Note: the rest of this PR description was for an older version of this PR and therefore collapsed.

<details>
  <summary>See prior PR description</summary>

As discussed [here](https://github.com/git-for-windows/git-for-windows-automation/issues/59#issuecomment-1821185442), let's add some cleanup logic for Azure VMs that we no longer need.

> Another idea: we should be able to teach GitForWindowsHelper to detect failed create-self-hosted-runner runs and automatically kick off the delete run, no?

In this PR, I added logic that goes through the resource group and deletes leftover VMs. That way, it's not strictly linked to failed runs. I think this is a more robust way to ensure leftover VMs are deleted, but very much open to ideas and feedback.

> And _maybe_ also try re-running the failed run, up to five times?

By "failed run", do you mean the run that creates the self hosted runner, or the run that does the actual build of GfW ARM64? Assuming you mean the former, we'll probably have to add some logic [here](https://github.com/git-for-windows/gfw-helper-github-app/blob/main/GitForWindowsHelper/index.js) to detect when a run that creates a self hosted runner has failed, then retry, right? Not sure if that's worth the effort tbh, as these jobs have been rock-solid until I tried again yesterday after some time of not doing it. It probably deserves some more investigation to ensure that VMs are created reliably again.
</details>

