### PR TITLE
build-and-deploy: use `update-via-pacman.ps1` instead of a home-grown `pacman -Syyu`

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -98,6 +98,7 @@ jobs:
 
       - name: Download Git for Windows SDK
         uses: git-for-windows/setup-git-for-windows-sdk@v1
+        id: setup-sdk
         with:
           flavor: ${{ env.PACKAGE_TO_BUILD == 'mingw-w64-git' && 'build-installers' || 'full' }}
           architecture: ${{ env.ARCHITECTURE || 'x86_64' }}
@@ -122,9 +123,10 @@ jobs:
         shell: bash
         run: git clone --depth 1 --single-branch -b main https://github.com/git-for-windows/build-extra /usr/src/build-extra
 
-      - name: pacman -Syyu
-        shell: bash
-        run: pacman -Syyu --noconfirm
+      - name: update the SDK ("pacman -Syyu")
+        shell: powershell
+        run: |
+          & ("${{ steps.setup-sdk.outputs.result }}\update-via-pacman.ps1")
 
       - name: rebase `.dll` base addresses
         if: env.ARCHITECTURE == 'i686'


### PR DESCRIPTION
Needs https://github.com/git-for-windows/build-extra/pull/539 to be merged first.

The intricacies of updating the Git for Windows SDKs are not _quite_ trivial. For one, you have to make sure to call `pacman` another time if "system packages" such as `msys2-runtime` have been updated. Also, in the end `mingw-w64-git-extra` has to be installed so that that package's post-install script can adjust a couple of system files in accordance with Git for Windows' requirements.

These intricacies are documented and automated in the `update-via-pacman.ps1` script that is run as part of the `sync` GitHub workflows that are installed in the `git-sdk-*` repositories.

It only makes sense to use the same automation when building Git for Windows' packages, so let's do this.

This fixes https://github.com/git-for-windows/git-for-windows-automation/issues/29