### PR TITLE
build-and-deploy: stop GPG agent before trying to remove GPG files

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -299,7 +299,10 @@ jobs:
       - name: Clean up temporary files
         if: always()
         shell: bash
-        run: rm -rf "$HOME"
+        run: |
+          gpgconf --kill dirmng &&
+          gpgconf --kill gpg-agent &&
+          rm -rf "$HOME"
 
       - name: mark check run as completed
         if: env.CREATE_CHECK_RUN != 'false' && always()


### PR DESCRIPTION
In the `build-and-deploy` GitHub workflow, we try to clean up the GPG files before finishing the job, but it seems that as of GPG v2.4.x, [this fails](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/7906810424/job/21582488405#step:20:20). In other words, it looks as if we need to stop the GPG agent before doing that. 

So let's do that, and while at it, also make sure that the `dirmngr` (GPG's daemon that takes care of talking to keyservers) is stopped, too.