### PR TITLE
github-release: in addition to the tag, also push `main`

### DIFF
--- a/.github/actions/github-release/action.yml
+++ b/.github/actions/github-release/action.yml
@@ -77,7 +77,7 @@ runs:
             checkSHA256Sums,
             createRelease,
             uploadGitArtifacts,
-            pushGitTag,
+            pushGitTagAndMainBranch,
             updateRelease
           } = require('./github-release')
 
@@ -126,7 +126,7 @@ runs:
           )
           await state.refreshToken()
 
-          await pushGitTag(
+          await pushGitTagAndMainBranch(
             console,
             core.setSecret,
             state.accessToken,

--- a/github-release.js
+++ b/github-release.js
@@ -244,7 +244,7 @@ const uploadGitArtifacts = async (context, token, owner, repo, releaseId, gitArt
   context.log('Done uploading Git artifacts')
 }
 
-const pushGitTag = (context, setSecret, token, owner, repo, tagName, bundlePath) => {
+const pushGitTagAndMainBranch = (context, setSecret, token, owner, repo, tagName, bundlePath) => {
   context.log(`Pushing Git tag ${tagName}`)
   const { callGit } = require('./repository-updates')
   callGit(['clone',
@@ -261,7 +261,7 @@ const pushGitTag = (context, setSecret, token, owner, repo, tagName, bundlePath)
   if (setSecret) setSecret(auth)
   callGit(['--git-dir', 'git',
     '-c', `http.extraHeader=Authorization: Basic ${auth}`,
-    'push', `https://github.com/${owner}/${repo}`, `refs/tags/${tagName}`
+    'push', `https://github.com/${owner}/${repo}`, `refs/tags/${tagName}`, `refs/tags/${tagName}^0:refs/heads/main`
   ])
   context.log('Done pushing tag')
 }
@@ -278,5 +278,5 @@ module.exports = {
   calculateSHA256ForFile,
   checkSHA256Sums,
   uploadGitArtifacts,
-  pushGitTag
+  pushGitTagAndMainBranch
 }


### PR DESCRIPTION
The idea is always to update the `main` branch after the Git for Windows release is done, to close the PR.

So far, this is done manually. But it's better to automate this. Because then I cannot make mistakes like merging via the `Merge` button (as I had done for v2.44.0-rc1, which complicated subsequent rebases) instead of pushing to `main`.

The downside would be that the PR would be closed before the `release` workflow run had a chance to finish, and therefore any failures may be harder to spot.