### PR TITLE
build-and-deploy: spell `dirmngr` correctly

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -300,7 +300,7 @@ jobs:
         if: always()
         shell: bash
         run: |
-          gpgconf --kill dirmng &&
+          gpgconf --kill dirmngr &&
           gpgconf --kill gpg-agent &&
           rm -rf "$HOME"
 


### PR DESCRIPTION
This was a mistake that slipped through via https://github.com/git-for-windows/git-for-windows-automation/pull/71.

This just broke the builds of `mintty` (_after_ successfully deploying the packages): [i686](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/8039156102/job/21955864065#step:20:22) and [x86_64](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/8039155942/job/21955863606#step:20:22).

The symptom is the error message "Component not found" in the "Clean up temporary files" step.