### PR TITLE
open-pr: allow `update-scripts` to add/modify/remove files

### DIFF
--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -135,7 +135,8 @@ jobs:
             updpkgsums
           fi &&
           msg="$PACKAGE_TO_UPGRADE: update to $UPGRADE_TO_VERSION" &&
-          git commit -sm "$msg" PKGBUILD &&
+          git add PKGBUILD &&
+          git commit -sm "$msg" &&
           echo "msg=$msg" >>$GITHUB_OUTPUT &&
           echo "modified=true" >>$GITHUB_OUTPUT
       - name: check if the package was already deployed


### PR DESCRIPTION
Sometimes the update script needs to add new patches and remove old ones, [as was the case for `mingw-w64-clang` 18.1.1](https://github.com/git-for-windows/MINGW-packages/actions/runs/8273672918/job/22637842941?pr=113#step:5:247).