### PR TITLE
workflows: add timeouts, address linter issues

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -162,6 +162,7 @@ jobs:
           bash -lc "set -x && rebase -v -i /usr/lib/perl5/core_perl/auto/Cwd/Cwd.dll"
 
       - name: Get GPG key(s)
+        timeout-minutes: 5
         shell: bash
         env:
           CARCH: x86_64 # dummy, to allow sourcing cv2pdb's PKGBUILD as-is

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -124,6 +124,7 @@ jobs:
         run: git clone --depth 1 --single-branch -b main https://github.com/git-for-windows/build-extra /usr/src/build-extra
 
       - name: update the SDK ("pacman -Syyu")
+        timeout-minutes: 20
         shell: powershell
         run: |
           & ("${{ steps.setup-sdk.outputs.result }}\update-via-pacman.ps1")
@@ -204,6 +205,7 @@ jobs:
           echo "SIGNTOOL=git signtool" >>$GITHUB_ENV
 
       - name: Build ${{env.PACKAGE_TO_BUILD}}
+        timeout-minutes: ${{ env.PACKAGE_TO_BUILD== 'mingw-w64-llvm' && 360 || 150 }}
         env:
           GPGKEY: ${{secrets.GPGKEY}}
           MAKEPKG: ${{ env.REPO != 'MSYS2-packages' && env.PACKAGE_TO_BUILD != 'git-for-windows-keyring' && 'makepkg-mingw' || 'makepkg' }}

--- a/.github/workflows/create-azure-self-hosted-runners.yml
+++ b/.github/workflows/create-azure-self-hosted-runners.yml
@@ -23,7 +23,7 @@ on:
         type: string
         required: true
         description: Deallocate the runner immediately after creating it (useful for spinning up runners preemptively)
-        default: false
+        default: "false"
 
 env:
   ACTIONS_RUNNER_SCOPE: ${{ github.event.inputs.runner_scope }}
@@ -157,6 +157,7 @@ jobs:
         deploymentName: deploy-${{ steps.generate-vm-name.outputs.vm_name }}
         template: ./azure-self-hosted-runners/azure-arm-template.json
         parameters: ./azure-self-hosted-runners/azure-arm-template-example-parameters.json ${{ env.AZURE_ARM_PARAMETERS }}
+        scope: resourcegroup
     
     - name: Show post-deployment script output
       env:

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -261,6 +261,7 @@ jobs:
           echo -n "$CODESIGN_PASS" >.sig/codesign.pass
           git config --global alias.signtool '!sh "/usr/src/build-extra/signtool.sh"'
       - name: Prepare home directory for GPG signing
+        timeout-minutes: 5
         if: env.GPGKEY != '' && steps.restore-cached-git-pkg.outputs.cache-hit != 'true'
         run: |
           echo '${{secrets.PRIVGPGKEY}}' | tr % '\n' | gpg $GPG_OPTIONS --import &&
@@ -277,6 +278,7 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           append-text: 'About to build the `${{env.MINGW_PACKAGE_PREFIX}}-git` package'
       - name: Build ${{env.MINGW_PACKAGE_PREFIX}}-git
+        timeout-minutes: 60
         if: steps.restore-cached-git-pkg.outputs.cache-hit != 'true'
         env:
           GPGKEY: "${{secrets.GPGKEY}}"


### PR DESCRIPTION
Last night, a `mingw-w64-openssl (aarch64)` job [timed out after 6h](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/9374447637/job/25810488159#step:12:28), which cost quite a bit of Azure resources.

The reason was most likely that finicky MSYS2 runtime which hangs on Windows/ARM64 quite often.

Let's add timeouts to workflows' steps to avoid incurring these Azure costs.