### PR TITLE
self-hosted runners: upgrade to 24h2

### DIFF
--- a/.github/workflows/create-azure-self-hosted-runners.yml
+++ b/.github/workflows/create-azure-self-hosted-runners.yml
@@ -39,7 +39,7 @@ env:
   # For more information, see https://learn.microsoft.com/en-us/azure/virtual-machines/dplsv5-dpldsv5-series (which
   # unfortunately does not have more information about price by region)
   AZURE_VM_REGION: westus2
-  AZURE_VM_IMAGE: win11-23h2-ent
+  AZURE_VM_IMAGE: win11-24h2-ent
 
 # The following secrets are required for this workflow to run:
 # AZURE_CREDENTIALS - Credentials for the Azure CLI. It's recommended to set up a resource


### PR DESCRIPTION
The 24h2 version of Windows 11 introduces a new x64 emulation engine: Prism. It promises improved performance, and maybe it'll help resolve some of the mysterious arm64 hangs we've been experiencing...

Ref: https://learn.microsoft.com/en-us/windows/arm/apps-on-arm-x86-emulation#prism