### PR TITLE
release: create a discussion for every Git for Windows release

### DIFF
--- a/github-release.js
+++ b/github-release.js
@@ -9,6 +9,7 @@ const createRelease = async (context, token, owner, repo, tagName, rev, name, bo
       target_commitish: rev,
       name,
       body,
+      discussion_category_name: 'Announcements',
       draft: draft === undefined ? true : draft,
       prerelease: prerelease === undefined ? true : prerelease
     }


### PR DESCRIPTION
It is a nice thing to have for users, and therefore I just created one for the latest Git for Windows version at
https://github.com/git-for-windows/git/discussions/5035.

Let's automate this.

For details about the used REST API endpoint, see
https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#update-a-release--parameters