### PR TITLE
open-pr: support updating InnoSetup

### DIFF
--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -35,6 +35,11 @@ jobs:
           mingw-w64-git-lfs|mingw-w64-git-sizer|mingw-w64-wintoast|\
           git-extra|git-for-windows-keyring) repo=build-extra;;
           mingw-w64-*) repo=MINGW-packages;;
+          innosetup)
+            repo=build-extra &&
+            echo "package_path=installer" >>$GITHUB_ENV &&
+            echo "skip-deployment-check=true" >>$GITHUB_OUTPUT
+            ;;
           *) repo=MSYS2-packages;;
           esac &&
           echo "REPO=$repo" >>$GITHUB_ENV &&
@@ -109,7 +114,7 @@ jobs:
         id: update
         shell: bash
         run: |
-          cd "/usr/src/$REPO/$PACKAGE_TO_UPGRADE" &&
+          cd "/usr/src/$REPO/${package_path-$PACKAGE_TO_UPGRADE}" &&
           update_script="$GITHUB_WORKSPACE/update-scripts/version/$PACKAGE_TO_UPGRADE"
           if test -f "$update_script"
           then
@@ -135,11 +140,12 @@ jobs:
             updpkgsums
           fi &&
           msg="$PACKAGE_TO_UPGRADE: update to $UPGRADE_TO_VERSION" &&
-          git add PKGBUILD &&
+          { test ! -f PKGBUILD || git add PKGBUILD; } &&
           git commit -sm "$msg" &&
           echo "msg=$msg" >>$GITHUB_OUTPUT &&
           echo "modified=true" >>$GITHUB_OUTPUT
       - name: check if the package was already deployed
+        if: steps.repo.outputs.skip-deployment-check != 'true'
         shell: bash
         run: |
           ./update-scripts/ensure-not-yet-deployed.sh "/usr/src/$REPO/$PACKAGE_TO_UPGRADE"
@@ -149,7 +155,7 @@ jobs:
         run: |
           auth="$(printf '%s:%s' '${{ steps.actor.outputs.login }}' '${{ steps.setup.outputs.token }}' | base64)" &&
           echo "::add-mask::$auth" &&
-          cd "/usr/src/$REPO/$PACKAGE_TO_UPGRADE" &&
+          cd "/usr/src/$REPO/${package_path-$PACKAGE_TO_UPGRADE}" &&
           git -c http.extraHeader="Authorization: Basic $auth" push --force origin HEAD:refs/heads/$PACKAGE_TO_UPGRADE-$UPGRADE_TO_VERSION
       - name: open PR
         if: steps.update.outputs.modified == 'true'

--- a/update-scripts/checksums/innosetup
+++ b/update-scripts/checksums/innosetup
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "::notice::No checksum update needed for Inno Setup" >&2

--- a/update-scripts/version/innosetup
+++ b/update-scripts/version/innosetup
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -x &&
+url="https://jrsoftware.org/download.php/innosetup-$1.exe" &&
+curl -# -LR -D curl.log -o is.exe "$url" &&
+cat curl.log &&
+grep 'HTTP/.* 200' curl.log &&
+./is.exe //verysilent //dir=InnoSetup //noicons //tasks= //portable=1 //lang=english \
+  //SP- //SUPPRESSMSGBOXES //NORESTART //LOG=is.log &&
+cat is.log &&
+git add -A InnoSetup/ &&
+git status


### PR DESCRIPTION
This is a companion PR to https://github.com/git-for-windows/gfw-helper-github-app/pull/88; Together, they allow updating InnoSetup via `/open pr` from within the tickets that are opened by [the `monitor-components` workflow](https://github.com/git-for-windows/git/actions/workflows/monitor-components.yml).

[Here](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/9907328672) is a successful run that opened https://github.com/git-for-windows/build-extra/pull/568 (the branch had one commit on top to trigger the build on `push`, which has been dropped before opening this here PR).