### PR TITLE
github-release: do create a discussion post for each new Git for Windows version

### DIFF
--- a/.github/actions/github-release/action.yml
+++ b/.github/actions/github-release/action.yml
@@ -147,7 +147,8 @@ runs:
             release.id, {
               draft: false,
               prerelease: isPrerelease,
-              make_latest : !isPrerelease
+              make_latest : !isPrerelease,
+              discussion_category_name: 'Announcements',
             }
           )
     - name: update check-run


### PR DESCRIPTION
This was the intention of #85, but that PR only changed the call that creates the draft release.

Apparently the intention to create a discussion post is _not_ stored when creating a draft release, though, sadly. Therefore we need to state that intention again when we do publish the release.

This problem was reported [here](https://github.com/git-for-windows/git-for-windows-automation/pull/85#issuecomment-2259878251).