### PR TITLE
self-hosted runners: use latest `pwsh` version now that arm64 MSIs are available

### DIFF
--- a/azure-self-hosted-runners/post-deployment-script.ps1
+++ b/azure-self-hosted-runners/post-deployment-script.ps1
@@ -119,9 +119,7 @@ catch {
 # It contains a bunch of new features compared to "powershell" and is sometimes more stable as well.
 #
 # url for Github API to get the latest release of pwsh
-#
-# TODO update this to /releases/latest once 7.5.0 is out, as it adds support for arm64 MSIs
-[string]$PwshUrl = "https://api.github.com/repos/PowerShell/PowerShell/releases/tags/v7.5.0-preview.2"
+[string]$PwshUrl = "https://api.github.com/repos/PowerShell/PowerShell/releases/latest"
 
 # Name of the MSI file that should be verified and downloaded
 [string]$PwshMsiName = "PowerShell-.*-win-arm64.msi"
@@ -237,10 +235,6 @@ $MsiArguments = "/qn /i  `"$MsiPath`" ADD_PATH=1"
 
 # Install pwsh using msiexec
 Start-Process msiexec.exe -Wait -ArgumentList $MsiArguments
-
-# TODO remove once 7.5.0 is out
-Write-Output "Copying pwsh-preview.cmd to pwsh.cmd as a temporary measure until 7.5.0 is out..."
-Copy-Item "C:\Program Files\PowerShell\7-preview\preview\pwsh-preview.cmd" "C:\Program Files\PowerShell\7-preview\preview\pwsh.cmd"  
 
 Write-Output "Finished installing pwsh."
 

--- a/azure-self-hosted-runners/post-deployment-script.ps1
+++ b/azure-self-hosted-runners/post-deployment-script.ps1
@@ -1,3 +1,5 @@
+#Requires -RunAsAdministrator
+
 param (
     # https://docs.github.com/en/actions/hosting-your-own-runners/adding-self-hosted-runners
     [Parameter(Mandatory = $true, HelpMessage = "GitHub Actions Runner registration token. Note that these tokens are only valid for one hour after creation, so we always expect the user to provide one.")]


### PR DESCRIPTION
Starting with version 7.4.3 of PowerShell, Windows arm64 MSIs [are added to the releases](https://github.com/PowerShell/PowerShell/releases/tag/v7.4.3), so we no longer need to hardcode the preview version.

Also, during local testing, I forgot to run PowerShell as administrator and the installation of `pwsh` silently failed. Let's [prevent the script from starting if we're not an admin](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_requires?view=powershell-7.4#-runasadministrator). This is mostly a nice to have for local testing, since the post-deployment script on the self-hosted runner always runs as admin.