### PR TITLE
self hosted runners: update Azure CLI version to latest

### DIFF
--- a/.github/workflows/create-azure-self-hosted-runners.yml
+++ b/.github/workflows/create-azure-self-hosted-runners.yml
@@ -168,6 +168,6 @@ jobs:
       if: env.DEALLOCATE_IMMEDIATELY == 'true'
       uses: azure/CLI@v2
       with:
-        azcliversion: 2.43.0
+        azcliversion: 2.64.0
         inlineScript: |
           az vm deallocate -n ${{ steps.generate-vm-name.outputs.vm_name }} -g ${{ secrets.AZURE_RESOURCE_GROUP }} --verbose

--- a/.github/workflows/delete-self-hosted-runner.yml
+++ b/.github/workflows/delete-self-hosted-runner.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Delete VM '${{ env.ACTIONS_RUNNER_NAME }}'
       uses: azure/CLI@v2
       with:
-        azcliversion: 2.43.0
+        azcliversion: 2.64.0
         inlineScript: |
           az vm delete -n "$ACTIONS_RUNNER_NAME" -g ${{ secrets.AZURE_RESOURCE_GROUP }} --yes
           az network nsg delete -n "$ACTIONS_RUNNER_NAME"-nsg -g ${{ secrets.AZURE_RESOURCE_GROUP }}


### PR DESCRIPTION
Let's use the latest version, as the one we're currently using is from December 2022.

Ref: https://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli#december-06-2022
Ref: https://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli#september-03-2024