### PR TITLE
Azure self-hosted runners: show logs on failure

### DIFF
--- a/.github/workflows/azure-login/action.yml
+++ b/.github/workflows/azure-login/action.yml
@@ -1,0 +1,43 @@
+name: Azure Login
+description: Logs into Azure using a service principal
+inputs:
+  credentials:
+    description: Your credentials in JSON format
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Process Azure credentials
+      uses: actions/github-script@v7
+      env:
+        AZURE_CREDENTIALS: ${{ inputs.credentials }}
+      with:
+        script: |
+          if (!process.env.AZURE_CREDENTIALS) {
+            core.setFailed('The AZURE_CREDENTIALS secret is required.')
+            process.exit(1)
+          }
+          
+          const azureCredentials = JSON.parse(process.env.AZURE_CREDENTIALS)
+          const {clientId, clientSecret, tenantId, subscriptionId} = azureCredentials
+
+          core.setSecret(clientId)
+          core.exportVariable('AZURE_CLIENT_ID', clientId)
+
+          core.setSecret(clientSecret)
+          core.exportVariable('AZURE_CLIENT_SECRET', clientSecret)
+
+          core.setSecret(tenantId)
+          core.exportVariable('AZURE_TENANT_ID', tenantId)
+
+          core.setSecret(subscriptionId)
+          core.exportVariable('AZURE_SUBSCRIPTION_ID', subscriptionId)
+    
+    - name: Azure Login
+      shell: bash
+      run: |
+        echo "Logging into Azure..."
+        az login --service-principal -u ${{ env.AZURE_CLIENT_ID }} -p ${{ env.AZURE_CLIENT_SECRET }} --tenant ${{ env.AZURE_TENANT_ID }}
+        echo "Setting subscription..."
+        az account set --subscription ${{ env.AZURE_SUBSCRIPTION_ID }} --output none

--- a/.github/workflows/cleanup-self-hosted-runners.yml
+++ b/.github/workflows/cleanup-self-hosted-runners.yml
@@ -21,38 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Process Azure credentials
-      uses: actions/github-script@v7
-      env:
-        AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+    - name: Azure Login
+      uses: ./.github/workflows/azure-login
       with:
-        script: |
-          if (!process.env.AZURE_CREDENTIALS) {
-            core.setFailed('The AZURE_CREDENTIALS secret is required.')
-            process.exit(1)
-          }
-          
-          const azureCredentials = JSON.parse(process.env.AZURE_CREDENTIALS)
-          const {clientId, clientSecret, tenantId, subscriptionId} = azureCredentials
+        credentials: ${{ secrets.AZURE_CREDENTIALS }}
 
-          core.setSecret(clientId)
-          core.exportVariable('AZURE_CLIENT_ID', clientId)
-
-          core.setSecret(clientSecret)
-          core.exportVariable('AZURE_CLIENT_SECRET', clientSecret)
-
-          core.setSecret(tenantId)
-          core.exportVariable('AZURE_TENANT_ID', tenantId)
-
-          core.setSecret(subscriptionId)
-          core.exportVariable('AZURE_SUBSCRIPTION_ID', subscriptionId)
     - name: Discover VMs to delete
       env:
         GH_APP_ID: ${{ secrets.GH_APP_ID }}
         GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
       run: |
-        az login --service-principal -u ${{ env.AZURE_CLIENT_ID }} -p ${{ env.AZURE_CLIENT_SECRET }} --tenant ${{ env.AZURE_TENANT_ID }}
-        az account set --subscription ${{ env.AZURE_SUBSCRIPTION_ID }}
         active_vms=$(az vm list -g ${{ secrets.AZURE_RESOURCE_GROUP }} | jq -c '.[] | {name,timeCreated}')
         current_time=$(date +%s)
         one_hour_ago=$(($current_time - 3600))

--- a/.github/workflows/create-azure-self-hosted-runners.yml
+++ b/.github/workflows/create-azure-self-hosted-runners.yml
@@ -158,6 +158,22 @@ jobs:
         template: ./azure-self-hosted-runners/azure-arm-template.json
         parameters: ./azure-self-hosted-runners/azure-arm-template-example-parameters.json ${{ env.AZURE_ARM_PARAMETERS }}
         scope: resourcegroup
+
+    - name: Show some more information on failure
+      if: failure()
+      run: |
+        echo "::group::VM status"
+        az vm get-instance-view --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --name ${{ steps.generate-vm-name.outputs.vm_name }} --query "instanceView.statuses"
+        az vm get-instance-view --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --name ${{ steps.generate-vm-name.outputs.vm_name }} --query "statuses"
+        echo "::endgroup::"
+
+        echo "::group::Deployment logs"
+        az group deployment show --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --name deploy-${{ steps.generate-vm-name.outputs.vm_name }}
+        echo "::endgroup::"
+
+        echo "::group::Extension logs"
+        az vm extension show --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --vm-name ${{ steps.generate-vm-name.outputs.vm_name }} --name CustomScriptExtension
+        echo "::endgroup::"
     
     - name: Show post-deployment script output
       env:

--- a/.github/workflows/create-azure-self-hosted-runners.yml
+++ b/.github/workflows/create-azure-self-hosted-runners.yml
@@ -176,6 +176,7 @@ jobs:
         echo "::endgroup::"
     
     - name: Show post-deployment script output
+      if: always()
       env:
         CUSTOM_SCRIPT_OUTPUT: ${{ steps.deploy-arm-template.outputs.customScriptInstanceView }}
       run: echo "$CUSTOM_SCRIPT_OUTPUT" | jq -r '.substatuses[0].message' 

--- a/.github/workflows/create-azure-self-hosted-runners.yml
+++ b/.github/workflows/create-azure-self-hosted-runners.yml
@@ -183,8 +183,4 @@ jobs:
 
     - name: Deallocate the VM for later use
       if: env.DEALLOCATE_IMMEDIATELY == 'true'
-      uses: azure/CLI@v2
-      with:
-        azcliversion: 2.64.0
-        inlineScript: |
-          az vm deallocate -n ${{ steps.generate-vm-name.outputs.vm_name }} -g ${{ secrets.AZURE_RESOURCE_GROUP }} --verbose
+      run: az vm deallocate -n ${{ steps.generate-vm-name.outputs.vm_name }} -g ${{ secrets.AZURE_RESOURCE_GROUP }} --verbose

--- a/.github/workflows/create-azure-self-hosted-runners.yml
+++ b/.github/workflows/create-azure-self-hosted-runners.yml
@@ -144,11 +144,11 @@ jobs:
         )
 
         echo "AZURE_ARM_PARAMETERS=$AZURE_ARM_PARAMETERS" >> $GITHUB_ENV
-        
+
     - name: Azure Login
-      uses: azure/login@v2
+      uses: ./.github/workflows/azure-login
       with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
+        credentials: ${{ secrets.AZURE_CREDENTIALS }}
     
     - uses: azure/arm-deploy@v2
       id: deploy-arm-template


### PR DESCRIPTION
We're [seeing](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/11025772033/job/30621189230) intermittent `OSProvisioningTimedOut` errors on VM creation, which typically happens within 20-40 mins of the deployment hanging. Most creation jobs seem to work fine, though.

Let's try and find out what's going wrong, so we can see if we need to fix things on our end.