### PR TITLE
release-git: add support for arm64

### DIFF
--- a/.github/actions/github-release/action.yml
+++ b/.github/actions/github-release/action.yml
@@ -39,6 +39,9 @@ inputs:
   git_artifacts_x86_64_workflow_run_id:
     description: 'ID of the git-artifacts (x86_64) workflow run'
     required: true
+  git_artifacts_aarch64_workflow_run_id:
+    description: 'ID of the git-artifacts (aarch64) workflow run'
+    required: true
 outputs:
   github-release-url:
     description: "The GitHub Release URL"
@@ -59,7 +62,7 @@ runs:
         rev: ${{ inputs.rev }}
         check-run-name: "github-release"
         title: "Publish ${{ inputs.display-version }} for @${{ inputs.rev }}"
-        summary: "Downloading the Git artifacts from ${{ inputs.git_artifacts_x86_64_workflow_run_id }} and ${{ inputs.git_artifacts_i686_workflow_run_id }} and publishing them as a new GitHub Release at ${{ inputs.owner }}/${{ inputs.repo }}"
+        summary: "Downloading the Git artifacts from ${{ inputs.git_artifacts_x86_64_workflow_run_id }}, ${{ inputs.git_artifacts_i686_workflow_run_id }} and ${{ inputs.git_artifacts_aarch64_workflow_run_id }} and publishing them as a new GitHub Release at ${{ inputs.owner }}/${{ inputs.repo }}"
         text: "For details, see [this run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}})."
         details-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}}"
     - name: Download bundle-artifacts (needed to push the tag)
@@ -97,7 +100,8 @@ runs:
             artifactsOwner,
             artifactsRepo,
             ${{ inputs.git_artifacts_i686_workflow_run_id }},
-            ${{ inputs.git_artifacts_x86_64_workflow_run_id }}
+            ${{ inputs.git_artifacts_x86_64_workflow_run_id }},
+            ${{ inputs.git_artifacts_aarch64_workflow_run_id }}
           )
 
           const sha256sums = sha256sumsFromReleaseNotes(${{ toJSON(inputs.release-notes) }})

--- a/.github/workflows/release-git.yml
+++ b/.github/workflows/release-git.yml
@@ -9,6 +9,9 @@ on:
       git_artifacts_x86_64_workflow_run_id:
         description: 'ID of the git-artifacts (x86_64) workflow run'
         required: true
+      git_artifacts_aarch64_workflow_run_id:
+        description: 'ID of the git-artifacts (aarch64) workflow run'
+        required: true
 
 env:
   HOME: "${{github.workspace}}\\home"
@@ -17,6 +20,7 @@ env:
   REPO: git
   I686_WORKFLOW_RUN_ID: "${{github.event.inputs.git_artifacts_i686_workflow_run_id}}"
   X86_64_WORKFLOW_RUN_ID: "${{github.event.inputs.git_artifacts_x86_64_workflow_run_id}}"
+  AARCH64_WORKFLOW_RUN_ID: "${{github.event.inputs.git_artifacts_aarch64_workflow_run_id}}"
 
 jobs:
   setup:
@@ -86,7 +90,8 @@ jobs:
               context.repo.owner,
               context.repo.repo,
               process.env.I686_WORKFLOW_RUN_ID,
-              process.env.X86_64_WORKFLOW_RUN_ID
+              process.env.X86_64_WORKFLOW_RUN_ID,
+              process.env.AARCH64_WORKFLOW_RUN_ID
             )
 
             core.setOutput('display-version', result.displayVersion)

--- a/github-release.js
+++ b/github-release.js
@@ -73,7 +73,8 @@ const downloadAndUnZip = async (token, url, name) => {
 
 const architectures = [
   { name: 'x86_64', infix: '-64-bit' },
-  { name: 'i686', infix: '-32-bit' }
+  { name: 'i686', infix: '-32-bit' },
+  { name: 'aarch64', infix: '-arm64' }
 ]
 
 const artifacts = [
@@ -96,11 +97,20 @@ const artifactName2Rank = (name) => {
   return rank
 }
 
-const downloadBundleArtifacts = async (context, token, owner, repo, git_artifacts_i686_workflow_run_id, git_artifacts_x86_64_workflow_run_id) => {
+const downloadBundleArtifacts = async (
+  context,
+  token,
+  owner,
+  repo,
+  git_artifacts_i686_workflow_run_id,
+  git_artifacts_x86_64_workflow_run_id,
+  git_artifacts_aarch64_workflow_run_id
+) => {
   for (const architecture of architectures) {
     const workflowRunId = {
       x86_64: git_artifacts_x86_64_workflow_run_id,
-      i686: git_artifacts_i686_workflow_run_id
+      i686: git_artifacts_i686_workflow_run_id,
+      aarch64: git_artifacts_aarch64_workflow_run_id
     }[architecture.name]
     const downloadURLs = await getWorkflowRunArtifactsURLs(context, token, owner, repo, workflowRunId)
     if (architecture.name === 'x86_64') await downloadAndUnZip(token, downloadURLs['bundle-artifacts'], 'bundle-artifacts')
@@ -162,17 +172,27 @@ const downloadBundleArtifacts = async (context, token, owner, repo, git_artifact
   return result
 }
 
-const getGitArtifacts = async (context, token, owner, repo, git_artifacts_i686_workflow_run_id, git_artifacts_x86_64_workflow_run_id) => {
+const getGitArtifacts = async (
+  context,
+  token,
+  owner,
+  repo,
+  git_artifacts_i686_workflow_run_id,
+  git_artifacts_x86_64_workflow_run_id,
+  git_artifacts_aarch64_workflow_run_id
+) => {
   const fs = require('fs')
   const result = []
   for (const architecture of architectures) {
     const workflowRunId = {
       x86_64: git_artifacts_x86_64_workflow_run_id,
-      i686: git_artifacts_i686_workflow_run_id
+      i686: git_artifacts_i686_workflow_run_id,
+      aarch64: git_artifacts_aarch64_workflow_run_id
     }[architecture.name]
 
     const urls = await getWorkflowRunArtifactsURLs(context, token, owner, repo, workflowRunId)
     for (const artifact of artifacts) {
+      if (architecture.name === 'aarch64' && artifact.name === 'mingit-busybox') continue
       const name = `${artifact.name}-${architecture.name}`
       context.log(`Downloading ${name}`)
       await downloadAndUnZip(token, urls[name], name)


### PR DESCRIPTION
Merge together with https://github.com/git-for-windows/gfw-helper-github-app/pull/110

The `git-artifacts` pipeline already supports ARM64, so we can add support for it in the `release-git` workflow as well.