### PR TITLE
release-git: add missing aarch64 input to github-release action

### DIFF
--- a/.github/actions/pacman-packages/action.yml
+++ b/.github/actions/pacman-packages/action.yml
@@ -33,6 +33,9 @@ inputs:
   git_artifacts_x86_64_workflow_run_id:
     description: 'ID of the git-artifacts (x86_64) workflow run'
     required: true
+  git_artifacts_aarch64_workflow_run_id:
+    description: 'ID of the git-artifacts (aarch64) workflow run'
+    required: true
   gpg-key:
     description: 'The GPG key to use to sign the updated Pacman database'
     required: true
@@ -58,7 +61,7 @@ runs:
         rev: ${{ inputs.rev }}
         check-run-name: "pacman-packages"
         title: "Deploy the mingw-w64-git packages ${{ inputs.display-version }}"
-        summary: "Downloading the Pacman packages from ${{ inputs.git_artifacts_x86_64_workflow_run_id }} and ${{ inputs.git_artifacts_i686_workflow_run_id }} and deploying them to the Pacman Repository"
+        summary: "Downloading the Pacman packages from ${{ inputs.git_artifacts_x86_64_workflow_run_id }}, ${{ inputs.git_artifacts_i686_workflow_run_id }}, and ${{ inputs.git_artifacts_aarch64_workflow_run_id }} and deploying them to the Pacman Repository"
         text: "For details, see [this run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}})."
         details-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}}"
     - name: Download artifacts
@@ -83,6 +86,15 @@ runs:
             artifactsRepo,
             ${{ inputs.git_artifacts_i686_workflow_run_id }},
             'pkg-i686'
+          )
+
+          await getWorkflowRunArtifact(
+            console,
+            ${{ toJSON(inputs.artifacts-token) }},
+            artifactsOwner,
+            artifactsRepo,
+            ${{ inputs.git_artifacts_aarch64_workflow_run_id }},
+            'pkg-aarch64'
           )
     - name: Download Git for Windows SDK
       uses: git-for-windows/setup-git-for-windows-sdk@v1
@@ -113,7 +125,7 @@ runs:
         GPGKEY: ${{ inputs.gpg-key }}
         azure_blobs_token: ${{ inputs.azure-blobs-token }}
       run: |
-        "$RUNNER_TEMP"/build-extra/pacman-helper.sh quick_add pkg-x86_64/*.tar.* pkg-i686/*.tar.*
+        "$RUNNER_TEMP"/build-extra/pacman-helper.sh quick_add pkg-x86_64/*.tar.* pkg-i686/*.tar.* pkg-aarch64/*.tar.*
     - name: update check-run
       if: always()
       uses: ./.github/actions/check-run-action

--- a/.github/workflows/release-git.yml
+++ b/.github/workflows/release-git.yml
@@ -125,6 +125,7 @@ jobs:
           artifacts-token: ${{ secrets.GITHUB_TOKEN }}
           git_artifacts_i686_workflow_run_id: ${{ env.I686_WORKFLOW_RUN_ID }}
           git_artifacts_x86_64_workflow_run_id: ${{ env.X86_64_WORKFLOW_RUN_ID }}
+          git_artifacts_aarch64_workflow_run_id: ${{ env.AARCH64_WORKFLOW_RUN_ID }}
   announcement-mail:
     needs: ['setup', 'github-release']
     runs-on: ubuntu-latest

--- a/.github/workflows/release-git.yml
+++ b/.github/workflows/release-git.yml
@@ -189,6 +189,7 @@ jobs:
           artifacts-token: ${{ secrets.GITHUB_TOKEN }}
           git_artifacts_i686_workflow_run_id: ${{ env.I686_WORKFLOW_RUN_ID }}
           git_artifacts_x86_64_workflow_run_id: ${{ env.X86_64_WORKFLOW_RUN_ID }}
+          git_artifacts_aarch64_workflow_run_id: ${{ env.AARCH64_WORKFLOW_RUN_ID }}
           gpg-key: ${{ secrets.GPGKEY }}
           priv-gpg-key: ${{ secrets.PRIVGPGKEY }}
           azure-blobs-token: ${{ secrets.AZURE_BLOBS_TOKEN }}


### PR DESCRIPTION
In earlier commits, we added suppport for ARM64 to the release pipelines, but there's a couple more places to update. Let's do that.