### PR TITLE
self-hosted runners: use native arm64 version of GfW

### DIFF
--- a/azure-self-hosted-runners/post-deployment-script.ps1
+++ b/azure-self-hosted-runners/post-deployment-script.ps1
@@ -47,7 +47,7 @@ Write-Output "Starting post-deployment script."
 [string]$GitHubUrl = "https://api.github.com/repos/git-for-windows/git/releases/latest"
 #
 # Name of the exe file that should be verified and downloaded
-[string]$GithubExeName = "Git-.*-64-bit.exe"
+[string]$GithubExeName = "Git-.*-arm64.exe"
 
 try {
     [System.Object]$GithubRestData = Invoke-RestMethod -Uri $GitHubUrl -Method Get -Headers $GithubHeaders -TimeoutSec 10 | Select-Object -Property assets, body


### PR DESCRIPTION
Closes #28 

2.47.1 is the first version of Git for Windows for which native arm64 binaries are being published. Let's use those moving forward, for better performance.

Ref: https://github.com/git-for-windows/git/releases/tag/v2.47.1.windows.1