### PR TITLE
post-deployment-script: fix regex for sha256

### DIFF
--- a/azure-self-hosted-runners/post-deployment-script.ps1
+++ b/azure-self-hosted-runners/post-deployment-script.ps1
@@ -52,7 +52,8 @@ Write-Output "Starting post-deployment script."
 try {
     [System.Object]$GithubRestData = Invoke-RestMethod -Uri $GitHubUrl -Method Get -Headers $GithubHeaders -TimeoutSec 10 | Select-Object -Property assets, body
     [System.Object]$GitHubAsset = $GithubRestData.assets | Where-Object { $_.name -match $GithubExeName }
-    if ($GithubRestData.body -match "\b${[Regex]::Escape($GitHubAsset.name)}.*?\|.*?([a-zA-Z0-9]{64})" -eq $True) {
+    $AssetNameEscaped = [Regex]::Escape($GitHubAsset.name)
+    if ($GithubRestData.body -match "\b${AssetNameEscaped}.*?\|.*?([a-zA-Z0-9]{64})" -eq $True) {
         [System.Object]$GitHubGit = [PSCustomObject]@{
             DownloadUrl = [string]$GitHubAsset.browser_download_url
             Hash        = [string]$Matches[1].ToUpper()


### PR DESCRIPTION
Follow-up of https://github.com/git-for-windows/git-for-windows-automation/pull/101

There was a bug in the regex that finds the sha256 hash corresponding to the Git binary. Doing things like `[Regex]::Escape` directly in a string interpolation, apparently isn't supported by PowerShell. It just returned an empty string in the string interpolation.

This has surprisingly worked until now, because `Git-2.47.1-64-bit.exe` was [always the first binary in the list of assets](https://github.com/git-for-windows/git/releases/tag/v2.47.1.windows.1), so the corresponding hash was found. Now that we're getting the native `-arm64.exe` binary, the bug in the logic got exposed.

This commit fixes the bug by assigning the escaped asset name to a dedicated variable first.