### PR TITLE
open-pr: fix the Git LFS link to use when opening a PR

### DIFF
--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -169,7 +169,7 @@ jobs:
               const version = process.env.UPGRADE_TO_VERSION
 
               if (name === 'mintty') body = `See https://github.com/mintty/mintty/releases/tag/${version} for details.`
-              else if (name === 'mingw-w64-git-lfs') body = `See https://github.com/git-lfs/git-lfs/releases/tag/${version} for details.`
+              else if (name === 'mingw-w64-git-lfs') body = `See https://github.com/git-lfs/git-lfs/releases/tag/v${version} for details.`
               else if (name === 'mingw-w64-pcre2') body = `See https://github.com/PCRE2Project/pcre2/blob/pcre2-${version}/ChangeLog for details.`
 
               const terms = 'type:issue repo:git-for-windows/git state:open author:app/github-actions label:component-update'


### PR DESCRIPTION
It has been [reported](https://github.com/git-for-windows/git/discussions/5276#discussioncomment-11396076) that the Git LFS link in the release notes was incorrect.

The reason is that we have some special handling of Git LFS so that we do not get the (rather ugly) _tag_ URL but instead the _release_ URL.

Example: https://github.com/git-for-windows/git/issues/5266 refers to https://github.com/git-lfs/git-lfs/releases/tag/v3.6.0 because this is the URL from [the feed from which the `monitor-components` gets it](https://github.com/git-for-windows/git/blob/v2.47.1.windows.1/.github/workflows/monitor-components.yml#L29-L3)

The [corresponding PR](https://github.com/git-for-windows/build-extra/pull/581) (opened via [`/open pr`](https://github.com/git-for-windows/git/issues/5266#issuecomment-2490815737)) has the link https://github.com/git-lfs/git-lfs/releases/tag/3.6.0 (note the missing `v` after the last slash).

This PR ensures that future `/open pr`s in Git LFS issues will use the correct link.