### PR TITLE
llvm: add changed patches

### DIFF
--- a/update-scripts/version/mingw-w64-llvm
+++ b/update-scripts/version/mingw-w64-llvm
@@ -1,2 +1,3 @@
 #!/bin/bash
-. ./update-clang-from-msys2.sh
+. ./update-clang-from-msys2.sh &&
+git add --all '*.patch'


### PR DESCRIPTION
As we noticed in https://github.com/git-for-windows/MINGW-packages/pull/132 the update script for llvm currently doesn't properly handle added or removed patches. This can break the llvm build. Update the script to handle these patches.