### PR TITLE
release-git: require the announcement email to be sent manually

### DIFF
--- a/.github/workflows/release-git.yml
+++ b/.github/workflows/release-git.yml
@@ -30,7 +30,6 @@ jobs:
       tag-name: ${{ steps.bundle-artifacts.outputs.tag-name }}
       ver: ${{ steps.bundle-artifacts.outputs.ver }}
       git-rev: ${{ steps.bundle-artifacts.outputs.git-rev }}
-      announcement: ${{ steps.bundle-artifacts.outputs.announcement }}
       release-notes: ${{ steps.bundle-artifacts.outputs.release-notes }}
     steps:
       - uses: actions/checkout@v4
@@ -99,7 +98,10 @@ jobs:
             core.setOutput('ver', result.ver)
             core.setOutput('git-rev', result.gitCommitOID)
 
-            core.setOutput('announcement', result.announcement)
+            core.startGroup('Announcement email')
+            core.info(result.announcement)
+            core.endGroup()
+
             core.setOutput('release-notes', result.releaseNotes)
       - name: Re-publish bundle-artifacts so the next job can easily use it
         uses: actions/upload-artifact@v4
@@ -126,23 +128,6 @@ jobs:
           git_artifacts_i686_workflow_run_id: ${{ env.I686_WORKFLOW_RUN_ID }}
           git_artifacts_x86_64_workflow_run_id: ${{ env.X86_64_WORKFLOW_RUN_ID }}
           git_artifacts_aarch64_workflow_run_id: ${{ env.AARCH64_WORKFLOW_RUN_ID }}
-  announcement-mail:
-    needs: ['setup', 'github-release']
-    runs-on: ubuntu-latest
-    steps:
-      - name: Mail announcement
-        uses: git-for-windows/git-for-windows-automation/.github/actions/mail-announcement@release
-        with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ env.OWNER }}
-          repo: ${{ env.REPO }}
-          display-version: ${{ needs.setup.outputs.display-version }}
-          rev: ${{ needs.setup.outputs.git-rev }}
-          announcement: ${{ needs.setup.outputs.announcement }}
-          smtp-server: ${{ secrets.SEND_ANNOUNCEMENT_SMTP_SERVER }}
-          smtp-login: ${{ secrets.SEND_ANNOUNCEMENT_SMTP_LOGIN }}
-          smtp-password: ${{ secrets.SEND_ANNOUNCEMENT_SMTP_PASSWORD }}
   gitforwindows-site:
     needs: ['setup', 'github-release']
     runs-on: ubuntu-latest


### PR DESCRIPTION
For quite a while now, those emails were rejected by the Git mailing list due to some Spamhaus rule. This is quite annoying, but cannot be helped because, well, because reasons.

So let's just print out the announcement email to the log, thusly requiring a manual step after the release is done.