### PR TITLE
git-artifacts: a couple of minor fixes

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -318,6 +318,7 @@ jobs:
           then
             echo "::warning::Uncommitted changes after build!" >&2 &&
             git diff >&2 &&
+            git commit -s -m "mingw-w64-git: new version ($version)" PKGBUILD &&
             git bundle create "$b"/MINGW-packages.bundle main^..main
           fi)
       - name: Cache ${{env.MINGW_PACKAGE_PREFIX}}-git

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -268,7 +268,8 @@ jobs:
           echo '${{secrets.PRIVGPGKEY}}' | tr % '\n' | gpg $GPG_OPTIONS --import &&
           info="$(gpg --list-keys --with-colons "${GPGKEY%% *}" | cut -d : -f 1,10 | sed -n '/^uid/{s|uid:||p;q}')" &&
           git config --global user.name "${info% <*}" &&
-          git config --global user.email "<${info#*<}"
+          git config --global user.email "<${info#*<}" &&
+          echo "PACKAGER=$info" >>$GITHUB_ENV
         env:
           GPGKEY: ${{secrets.GPGKEY}}
       - name: update check-run

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -308,7 +308,7 @@ jobs:
           if test -z "$EXISTING_GIT_TAG"
           then
             git commit -s -m "mingw-w64-git: new version ($version)" PKGBUILD &&
-          git bundle create "$b"/MINGW-packages.bundle origin/main..main
+            git bundle create "$b"/MINGW-packages.bundle origin/main..main
           elif ! git update-index --ignore-submodules --refresh ||
             ! git diff-files --ignore-submodules ||
             ! git diff-index --cached --ignore-submodules HEAD

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -1,5 +1,5 @@
 name: git-artifacts
-run-name: Build git-artifacts (${{ inputs.architecture }})
+run-name: Build git-artifacts (${{ inputs.artifacts != '' && format('{0} ', inputs.artifacts) || '' }}${{ inputs.architecture }})
 
 on:
   workflow_dispatch:

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -45,7 +45,7 @@ jobs:
   pkg:
     runs-on: ${{ github.event.inputs.architecture == 'aarch64' && fromJSON('["Windows", "ARM64"]') || 'windows-latest' }}
     outputs:
-      artifact_matrix: ${{steps.artifact-build-matrix.outputs.matrix}}
+      artifact_matrix: ${{ steps.artifact-build-matrix.outputs.result }}
       msystem: ${{steps.configure-environment.outputs.MSYSTEM}}
       mingw_package_prefix: ${{steps.configure-environment.outputs.MINGW_PACKAGE_PREFIX}}
       sdk_repo_arch: ${{steps.configure-environment.outputs.SDK_REPO_ARCH}}
@@ -195,7 +195,7 @@ jobs:
             try {
               const output = createArtifactsMatrix(process.env.ARTIFACTS_TO_BUILD, process.env.ARCHITECTURE)
               core.info(`Will be using the following matrix: ${JSON.stringify(output)}`)
-              core.setOutput('matrix', output)
+              return output
             } catch (e) {
               core.setFailed(e.message)
             }

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -287,7 +287,10 @@ jobs:
           set -x
           BUILD_SRC=$(test x86_64 != "$ARCHITECTURE" || echo "--build-src-pkg")
           # Make sure that there is a `/usr/bin/git` that can be used by `makepkg-mingw`
-          printf '#!/bin/sh\n\nexec '$MINGW_PREFIX'/bin/git.exe "$@"\n' >/usr/bin/git &&
+          if test ! -x /usr/bin/git
+          then
+            printf '#!/bin/sh\n\nexec '$MINGW_PREFIX'/bin/git.exe "$@"\n' >/usr/bin/git
+          fi &&
           (
             cd /usr/src/MINGW-packages/mingw-w64-git/src/git &&
             /usr/src/build-extra/please.sh build-mingw-w64-git --reset-pkgrel --only-$ARCHITECTURE $BUILD_SRC \


### PR DESCRIPTION
I ran into so many troubles while working on v2.48.0-rc2 that I decided to take a bit of time to look carefully at all the changes that were integrated over the holidays (when most people stayed away from their keyboards, and I should have done the same). While kicking the tires of Git for Windows v2.48.0-rc1 I noticed that the Pacman package recorded a different packager than signer. And after I was half-way through debugging this, I realized that I had already fixed this during the embargoed release last year.

And sure enough, when I looked at the commits that I had meant to merge back into `git-for-windows-automation`, I found the fix: https://github.com/git-for-windows/git-for-windows-automation/commit/ff048920f66406594a053b003d3cc43d585f5f37

Sadly, the commits are in nowhere near the shape they would need to be to get merged: https://github.com/git-for-windows/git-for-windows-automation/compare/embargoed-builds. So I'll need to spend a lot of time on polishing them, but given that I am _still_ not ready to release Git for Windows v2.48.0-rc2, even though _Git v2.48.0 is supposed to be released tomorrow, that project will have to wait a little.

But here is a thing I _can_ do, to at least get the benefit of _some_ of the patches sooner rather than later: I cherry-picked the most obviously-good patches.