### PR TITLE
release-git: rank ARM64 higher than 32-bit

### DIFF
--- a/github-release.js
+++ b/github-release.js
@@ -92,8 +92,8 @@ const ranked = artifacts
 const artifactName2Rank = (name) => {
   let rank = ranked.indexOf(name
     .replace(/-\d+(\.\d+)*(-rc\d+)?/, '')
-    .replace(/-(32|64)-bit/, '')
-  ) + (name.indexOf('-64-bit') > 0 ? 0.5 : 0)
+    .replace(/-((32|64)-bit|arm64)/, '')
+  ) + (name.indexOf('-64-bit') > 0 ? 0.5 : (name.indexOf('-arm64') > 0 ? 0.3 : 0))
   return rank
 }
 


### PR DESCRIPTION
The SHA-256 checksums of the Git for Windows release artifacts are listed at the bottom of Git for Windows' announcement emails.

Certain of those artifacts are deemed more important than others and are hence listed first. For example, x86_64 is nowadays considered much more important than i686 (which is deprecated, after all). To present the artifacts in such an order, the `artifactName2Rank()` function hard-codes CPU architecture rankings.

When ARM64 artifacts were included, this ranking was not adjusted, and as a consequence ARM64 ranked way on the bottom. However, ARM64 is the future (or will be, once GitHub comes through with the promise of hosted runners) because of battery life, performance potentials, etc, and it should therefore outrank i686.

Let's make it so!