### PR TITLE
open-pr: use more pleasant commit/PR titles when handling the `msys2-runtime` package

### DIFF
--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -118,7 +118,12 @@ jobs:
           update_script="$GITHUB_WORKSPACE/update-scripts/version/$PACKAGE_TO_UPGRADE"
           if test -f "$update_script"
           then
-            $update_script "$UPGRADE_TO_VERSION"
+            $update_script "$UPGRADE_TO_VERSION" &&
+            if test -f UPGRADE_TO_VERSION
+            then
+              UPGRADE_TO_VERSION="$(cat UPGRADE_TO_VERSION)" &&
+              rm UPGRADE_TO_VERSION
+            fi
           else
             sed -i \
               -e "s/^\\(pkgver=\\).*/\\1$UPGRADE_TO_VERSION/" \

--- a/update-scripts/version/bash
+++ b/update-scripts/version/bash
@@ -11,7 +11,7 @@
 
     let [ , basever, patchlevel ] = version.match(/^(\d+\.\d+)\.(\d+)/)
     let match
-    
+
     const fs = require('fs')
     const lines = fs.readFileSync('PKGBUILD').toString('utf-8').split(/\r?\n/)
     lines.forEach((line, i) => {

--- a/update-scripts/version/msys2-runtime
+++ b/update-scripts/version/msys2-runtime
@@ -76,4 +76,6 @@ if test -n "$update_pkgver"
 then
     git reset --soft HEAD^ &&
     sed -i 's/^pkgrel=.*/pkgrel=1/' PKGBUILD
-fi
+fi &&
+sed -n '/^pkgver=/{:1;N;/pkgrel=/{s/.*pkgver=\([0-9\.]*\).*pkgrel=\([0-9]*\).*/\1-\2/p;q};b1}' \
+    <PKGBUILD >UPGRADE_TO_VERSION


### PR DESCRIPTION
Previously, we used the title `msys2-runtime: update to <commit OID>` which is as correct as it is unhelpful.

Let's use `<pkgver>-<pkgrel>`  instead of `<commit OID>`. Proof that it works: [the `open-pr` run](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/13006636896/job/36274972609) that opened https://github.com/git-for-windows/MSYS2-packages/pull/210.