### PR TITLE
tag-git: use the new Git for Windows snapshots URL

### DIFF
--- a/update-scripts/tag-git.sh
+++ b/update-scripts/tag-git.sh
@@ -94,7 +94,7 @@ else
 
 	case "$display_version" in
 	prerelease-*)
-		url=https://wingit.blob.core.windows.net/files/index.html
+		url=https://gitforwindows.org/git-snapshots/
 		;;
 	*-rc*)
 		url=https://github.com/git-for-windows/git/releases/tag/$tag_name


### PR DESCRIPTION
For almost eight years, Git for Windows' snapshots were hosted at https://wingit.blob.core.windows.net/files/index.html, i.e. on Azure Blobs.

As of a combination of PRs (https://github.com/git-for-windows/git-for-windows-automation/pull/109, https://github.com/git-for-windows/gfw-helper-github-app/pull/117), snapshots are not only now built and deployed via GitHub Actions instead of Azure Pipelines (and ARM64 artifacts are now included, too), they are also hosted [on GitHub](https://github.com/git-for-windows/git-snapshots/releases/), with the main page being hosted [on GitHub Pages](https://github.com/git-for-windows/git-snapshots/commits/gh-pages).

Therefore, the original link now redirects to a new location (which is also a lot easier to remember): http://gitforwindows.org/git-snapshots. Let's adjust the link to link there directly.