### PR TITLE
upload-snapshot: include the Git for Windows installers in the snapshots again

### DIFF
--- a/.github/workflows/upload-snapshot.yml
+++ b/.github/workflows/upload-snapshot.yml
@@ -132,7 +132,7 @@ jobs:
             const assetsToUpload = directories
               .map(directory => fs
                   .readdirSync(directory)
-                  .filter(file => file.match(/^(Min|Portable)Git-.*\.(exe|zip)$/))
+                  .filter(file => file.match(/^(Min|Portable)?Git-.*\.(exe|zip)$/))
                   .map(file => `${directory}/${file}`))
               .flat()
             if (assetsToUpload.length === 0) throw new Error(`No assets to upload!`)


### PR DESCRIPTION
This was a clear oversight of mine: the `Min` and `Portable` prefix before `Git` are _optional_, otherwise _only_ MinGits and PortableGits get included in the snapshot (which is what happened over the past couple of snapshots, e.g. [here](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/13207883283/job/36875241639#step:5:75), which I will have to fix separately).