### PR TITLE
Start transitioning to Git for Windows' new Pacman repository

### DIFF
--- a/.github/actions/pacman-packages/action.yml
+++ b/.github/actions/pacman-packages/action.yml
@@ -118,12 +118,20 @@ runs:
         mkdir -p "$HOME" &&
         echo '${{ inputs.priv-gpg-key }}' | tr % '\n' | gpg $GPG_OPTIONS --import &&
         git config --global gpg.program "$RUNNER_TEMP/build-extra/gnupg-with-gpgkey.sh"
+    - uses: actions/create-github-app-token@v1
+      id: pacman-repo-token
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: ${{ inputs.owner }}
+        repositories: pacman-repo
     - name: Upload Pacman packages
       shell: bash
       env:
         GPG_OPTIONS: "--batch --yes --no-tty --list-options no-show-photos --verify-options no-show-photos --pinentry-mode loopback"
         GPGKEY: ${{ inputs.gpg-key }}
         azure_blobs_token: ${{ inputs.azure-blobs-token }}
+        GITHUB_TOKEN: ${{ steps.pacman-repo-token.outputs.token }}
       run: |
         "$RUNNER_TEMP"/build-extra/pacman-helper.sh quick_add pkg-x86_64/*.tar.* pkg-i686/*.tar.* pkg-aarch64/*.tar.*
     - name: update check-run

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -306,22 +306,13 @@ jobs:
           name: artifacts
           path: artifacts
 
-      - name: Prepare home directory for deploying to the Pacman repository
-        if: env.BUILD_ONLY != 'true' && env.AZURE_BLOBS_TOKEN != ''
-        env:
-          AZURE_BLOBS_TOKEN: ${{secrets.AZURE_BLOBS_TOKEN}}
-        shell: bash
-        run: |
-          echo "::add-mask::$(echo "$AZURE_BLOBS_TOKEN" | base64 -w 0)" &&
-          echo "$AZURE_BLOBS_TOKEN" >"$HOME"/.azure-blobs-token
-
       - name: ${{ env.BUILD_ONLY == 'true' && 'Test-deploy' || 'Deploy' }} Pacman packages
-        if: env.BUILD_ONLY == 'true' || env.AZURE_BLOBS_TOKEN != ''
+        if: env.BUILD_ONLY == 'true' || env.azure_blobs_token != ''
         shell: bash
         env:
           GPGKEY: ${{secrets.GPGKEY}}
           PACMANDRYRUN: ${{env.BUILD_ONLY}}
-          AZURE_BLOBS_TOKEN: ${{secrets.AZURE_BLOBS_TOKEN}}
+          azure_blobs_token: ${{secrets.AZURE_BLOBS_TOKEN}}
         run: /usr/src/build-extra/pacman-helper.sh quick_add artifacts/*
 
       - name: Clean up temporary files

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -306,6 +306,14 @@ jobs:
           name: artifacts
           path: artifacts
 
+      - uses: actions/create-github-app-token@v1
+        id: pacman-repo-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: pacman-repo
+
       - name: ${{ env.BUILD_ONLY == 'true' && 'Test-deploy' || 'Deploy' }} Pacman packages
         if: env.BUILD_ONLY == 'true' || env.azure_blobs_token != ''
         shell: bash
@@ -313,6 +321,7 @@ jobs:
           GPGKEY: ${{secrets.GPGKEY}}
           PACMANDRYRUN: ${{env.BUILD_ONLY}}
           azure_blobs_token: ${{secrets.AZURE_BLOBS_TOKEN}}
+          GITHUB_TOKEN: ${{ steps.pacman-repo-token.outputs.token }}
         run: /usr/src/build-extra/pacman-helper.sh quick_add artifacts/*
 
       - name: Clean up temporary files


### PR DESCRIPTION
To disentangle Git for Windows' Pacman repository from my personal Azure account a bit, I started transitioning it to https://github.com/git-for-windows/pacman-repo.

In https://github.com/git-for-windows/build-extra/pull/595, I prepare `pacman-helper.sh` (which is Git for Windows' work horse for Pacman package deployments) to dual-deploy both to the old and to the new Pacman repository. Naturally, this needs the appropriate GitHub token to work. So here is the PR to adjust _the_ two remaining call sites in Git for Windows' automation to provide said token.