### PR TITLE
Follow-up fixes for the workflow to remove packages from Git for Windows' Pacman repository

### DIFF
--- a/.github/workflows/remove-packages-from-pacman-repository.yml
+++ b/.github/workflows/remove-packages-from-pacman-repository.yml
@@ -1,4 +1,4 @@
-name: remove-packages-from-pacman-repository
+name: Remove Packages from the Pacman repository
 run-name: Remove ${{ inputs.packages }} from the Pacman repository
 
 on:

--- a/.github/workflows/remove-packages-from-pacman-repository.yml
+++ b/.github/workflows/remove-packages-from-pacman-repository.yml
@@ -33,9 +33,7 @@ jobs:
       - name: Download Git for Windows SDK
         uses: git-for-windows/setup-git-for-windows-sdk@v1
         with:
-          flavor: makepkg-git
-          architecture: x86_64
-          msys: true
+          flavor: build-installers
 
       - name: Clone build-extra
         shell: bash


### PR DESCRIPTION
This, combined with https://github.com/git-for-windows/build-extra/pull/598, fixes the `remove-packages-from-pacman-repository` workflow.