### PR TITLE
self-hosted-runner: run the Actions runner under the SYSTEM account

### DIFF
--- a/azure-self-hosted-runners/post-deployment-script.ps1
+++ b/azure-self-hosted-runners/post-deployment-script.ps1
@@ -275,7 +275,7 @@ If ($Ephemeral -ne 'true') {
 }
 
 Write-Output "Configuring the runner"
-cmd.exe /c "${GitHubActionsRunnerPath}\config.cmd" --unattended $EphemeralOption --name ${GithubActionsRunnerName} --runasservice --labels $($GitHubAction.RunnerLabels) --url ${GithubActionsRunnerRegistrationUrl} --token ${GitHubActionsRunnerToken}
+cmd.exe /c "${GitHubActionsRunnerPath}\config.cmd" --unattended $EphemeralOption --name ${GithubActionsRunnerName} --windowslogonaccount "NT AUTHORITY\SYSTEM" --runasservice --labels $($GitHubAction.RunnerLabels) --url ${GithubActionsRunnerRegistrationUrl} --token ${GitHubActionsRunnerToken}
 
 # Ensure that the service was created. If not, exit with error code.
 if ($null -eq (Get-Service -Name "actions.runner.*")) {


### PR DESCRIPTION
Previously, the Actions runner was run under the `NT AUTHORITY\NETWORK SERVICE` account, which lacks the permissions to install Git for Windows. However, that is precisely what the `git-artifacts` workflow is supposed to do.

Tweaking the `./config.cmd` invocation by adding `--windowslogonaccount "NT AUTHORITY\SYSTEM"`` fixes the issue.