### PR TITLE
git-artifacts: stop building i686 artifacts except MinGit

### DIFF
--- a/create-artifacts-matrix.js
+++ b/create-artifacts-matrix.js
@@ -7,26 +7,27 @@ module.exports = (artifactsString, architecture) => {
 
     const validArtifacts = [
         {
-            name: 'installer',
-            filePrefix: 'Git',
-            fileExtension: 'exe'
-        },
-        {
-            name: 'portable',
-            filePrefix: 'PortableGit',
-            fileExtension: 'exe'
-        },
-        {
-            name: 'archive',
-            filePrefix: 'Git',
-            fileExtension: 'tar.bz2'
-        },
-        {
             name: 'mingit',
             filePrefix: 'MinGit',
             fileExtension: 'zip'
         }
     ]
+
+    if (architecture !== 'i686') validArtifacts.unshift({
+        name: 'installer',
+        filePrefix: 'Git',
+        fileExtension: 'exe'
+    },
+    {
+        name: 'portable',
+        filePrefix: 'PortableGit',
+        fileExtension: 'exe'
+    },
+    {
+        name: 'archive',
+        filePrefix: 'Git',
+        fileExtension: 'tar.bz2'
+    })
 
     if (architecture !== 'aarch64') validArtifacts.push({
         name: 'mingit-busybox',


### PR DESCRIPTION
As announced multiple times and also documented in detail at https://gitforwindows.org/32-bit, Git for Windows will no longer publish 32-bit installers, portable Gits and such.

The only i686 artifacts that will be published are the MinGit ones, until April 2029.

This addresses https://github.com/git-for-windows/git/issues/5394.