### PR TITLE
git-artifacts: _really_ stop building i686 artifacts except MinGit

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -167,7 +167,8 @@ jobs:
           echo "MINGW_PACKAGE_PREFIX=$MINGW_PACKAGE_PREFIX" >> $GITHUB_OUTPUT
           echo "SDK_REPO_ARCH=$SDK_REPO_ARCH" >> $GITHUB_OUTPUT
           test -n "$ARTIFACTS_TO_BUILD" || {
-            ARTIFACTS_TO_BUILD="installer portable archive mingit"
+            ARTIFACTS_TO_BUILD="mingit"
+            test "$ARCHITECTURE" = i686 || ARTIFACTS_TO_BUILD="installer portable archive $ARTIFACTS_TO_BUILD"
             test "$ARCHITECTURE" = aarch64 || ARTIFACTS_TO_BUILD="$ARTIFACTS_TO_BUILD mingit-busybox"
             test "$ARCHITECTURE" != x86_64 || ARTIFACTS_TO_BUILD="$ARTIFACTS_TO_BUILD nuget"
           }


### PR DESCRIPTION
In #117, I already tried to address this. But I forgot that the default, if left unspecified which artifacts to build, is to build all of them (with "all" being hard-coded also in the `Configure environment` step of the `git-artifacts` workflow).

So let's adjust this step, too.

This closes https://github.com/git-for-windows/git/issues/5394.