### PR TITLE
Fix breaking the Pacman lease

### DIFF
--- a/.github/workflows/break-pacman-upload-lease.yml
+++ b/.github/workflows/break-pacman-upload-lease.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone build-extra
-        shell: bash
-        run: git clone --depth 1 --single-branch -b main https://github.com/git-for-windows/build-extra /usr/src/build-extra
+        uses: actions/checkout@v4
+        with:
+          repository: git-for-windows/build-extra
 
       - name: Prepare home directory
         if: env.AZURE_BLOBS_TOKEN != ''
@@ -26,4 +27,5 @@ jobs:
         shell: bash
         env:
           AZURE_BLOBS_TOKEN: ${{secrets.AZURE_BLOBS_TOKEN}}
-        run: /usr/src/build-extra/pacman-helper.sh break_lock
+        run: |
+          ./pacman-helper.sh break_lock

--- a/.github/workflows/break-pacman-upload-lease.yml
+++ b/.github/workflows/break-pacman-upload-lease.yml
@@ -27,9 +27,3 @@ jobs:
         env:
           AZURE_BLOBS_TOKEN: ${{secrets.AZURE_BLOBS_TOKEN}}
         run: /usr/src/build-extra/pacman-helper.sh break_lock
-
-      - name: Clean up temporary files
-        if: always()
-        shell: bash
-        run: |
-          { rm -rf "$HOME" || echo "Gracefully leaving files undeleted" >&2; }

--- a/.github/workflows/break-pacman-upload-lease.yml
+++ b/.github/workflows/break-pacman-upload-lease.yml
@@ -12,20 +12,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: git-for-windows/build-extra
-
-      - name: Prepare home directory
-        if: env.AZURE_BLOBS_TOKEN != ''
-        env:
-          AZURE_BLOBS_TOKEN: ${{secrets.AZURE_BLOBS_TOKEN}}
+      - name: Break the lease
+        if: env.azure_blobs_token != ''
         shell: bash
+        env:
+          azure_blobs_token: ${{secrets.AZURE_BLOBS_TOKEN}}
         run: |
           echo "::add-mask::$(echo "$AZURE_BLOBS_TOKEN" | base64 -w 0)" &&
-          echo "$AZURE_BLOBS_TOKEN" >"$HOME"/.azure-blobs-token
-
-      - name: Break the lease
-        if: env.AZURE_BLOBS_TOKEN != ''
-        shell: bash
-        env:
-          AZURE_BLOBS_TOKEN: ${{secrets.AZURE_BLOBS_TOKEN}}
-        run: |
           ./pacman-helper.sh break_lock

--- a/.github/workflows/break-pacman-upload-lease.yml
+++ b/.github/workflows/break-pacman-upload-lease.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   break-lease:
-    if: github.event.repository.owner.login == 'git-for-windows'
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone build-extra

--- a/.github/workflows/break-pacman-upload-lease.yml
+++ b/.github/workflows/break-pacman-upload-lease.yml
@@ -1,5 +1,4 @@
-name: break-pacman-upload-lease
-run-name: Break pacman upload lease
+name: Break Pacman Upload Lease
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
It probably won't matter for much longer, but I finally figured out why on Earth the workflow run was skipped consistently: It was the clean-up step (which apparently looked nefarious to some automated gatekeeper tasked to keep miners out of Actions).