### PR TITLE
No longer post to the now-retired Google Group

### DIFF
--- a/update-scripts/tag-git.sh
+++ b/update-scripts/tag-git.sh
@@ -107,7 +107,7 @@ else
 	From ${tag_name#v} Mon Sep 17 00:00:00 2001
 	From: $(git var GIT_COMMITTER_IDENT | sed -e 's/>.*/>/')
 	Date: $(date -R)
-	To: git-for-windows@googlegroups.com, git@vger.kernel.org, git-packagers@googlegroups.com
+	To: git@vger.kernel.org, git-packagers@googlegroups.com
 	Subject: [ANNOUNCE] Git for Windows $display_version
 	Content-Type: text/plain; charset=UTF-8
 	Content-Transfer-Encoding: 8bit


### PR DESCRIPTION
As per https://github.com/git-for-windows/git/discussions/5473, Git for Windows' Google Group is shut down.