### PR TITLE
tag-git: accommodate for upstream's `.txt` -> `.adoc` rename

### DIFF
--- a/update-scripts/tag-git.sh
+++ b/update-scripts/tag-git.sh
@@ -55,8 +55,8 @@ else
 		if ! grep -q "^\\* Comes with \\[Git $base_tag\\]" "$build_extra_dir"/ReleaseNotes.md
 		then
 			url=https://github.com/git/git/blob/$base_tag &&
-			txt="$(echo "${base_tag#v}" | sed 's/-rc[0-9]*$//').txt" &&
-			url=$url/Documentation/RelNotes/$txt &&
+			adoc="$(echo "${base_tag#v}" | sed 's/-rc[0-9]*$//').adoc" &&
+			url=$url/Documentation/RelNotes/$adoc &&
 			release_note="Comes with [Git $base_tag]($url)." &&
 			(cd "$build_extra_dir" && node ./add-release-note.js --commit feature "$release_note")
 		fi


### PR DESCRIPTION
This is a companion of https://github.com/git-for-windows/build-extra/pull/607

/cc @orgads