### PR TITLE
Prepare for i686-only MINGW builds

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -8,7 +8,7 @@ on:
         description: 'The package to build'
         required: true
       build_only:
-        description: 'Skip deployment (if non-empty)'
+        description: 'Skip deployment (if "true")'
         required: false
       repo:
         description: 'The repo containing the package definition'
@@ -115,6 +115,7 @@ jobs:
           git -C /usr/src/$REPO reset --hard FETCH_HEAD
 
       - name: check if the package was already deployed
+        if: env.BUILD_ONLY != 'true'
         shell: bash
         run: |
           ./update-scripts/ensure-not-yet-deployed.sh${{ env.ARCHITECTURE != '' && format(' --architecture={0}', env.ARCHITECTURE) || '' }} "/usr/src/$REPO/$PACKAGE_TO_BUILD"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -241,10 +241,12 @@ jobs:
           MINGW_ARCHS_TO_BUILD=$(
                     case "$ARCHITECTURE,$PACKAGE_TO_BUILD" in
                     aarch64,*) echo "clangarm64";;
-                    *,mingw-w64-wintoast) echo "mingw32 mingw64 clangarm64";; # We're (cross-)compiling via Visual Studio
-                    *,mingw-w64-git-credential-manager) echo "mingw32 mingw64 clangarm64";; # We're downloading the pre-built x86 artifacts and using them for all three platforms
-                    *,mingw-w64-git-lfs) echo "mingw32 mingw64 clangarm64";; # We're downloading the pre-built artifacts from Git LFS' official release page
-                    *) echo "mingw32 mingw64";;
+                    x86_64,*) echo "mingw64";;
+                    i686,*) echo "mingw32";;
+                    ,mingw-w64-wintoast) echo "mingw32 mingw64 clangarm64";; # We're (cross-)compiling via Visual Studio
+                    ,mingw-w64-git-credential-manager) echo "mingw32 mingw64 clangarm64";; # We're downloading the pre-built x86 artifacts and using them for all three platforms
+                    ,mingw-w64-git-lfs) echo "mingw32 mingw64 clangarm64";; # We're downloading the pre-built artifacts from Git LFS' official release page
+                    ,*) echo "mingw32 mingw64";;
                     esac
           )
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -105,30 +105,6 @@ jobs:
           architecture: ${{ env.ARCHITECTURE || 'x86_64' }}
           msys: ${{ env.REPO == 'MSYS2-packages' || env.PACKAGE_TO_BUILD == 'git-for-windows-keyring' }}
 
-      - name: work around curl v8.11.0-1 problem
-        if: env.PACKAGE_TO_BUILD == 'curl' && env. REF == 'd58b04ae4163fe6c6c25b330bea0930d7bb627ac'
-        shell: bash
-        run: |
-          # `git fetch` does not work with that libcurl version. For details,
-          # see https://github.com/git-for-windows/MSYS2-packages/pull/199
-          test ! -f /var/lib/pacman/local/libcurl-8.11.0-1/desc ||
-          for pkg in libcurl curl
-          do
-            case "$ARCHITECTURE" in
-            i686) url=https://wingit.blob.core.windows.net/i686/$pkg-8.10.1-1-i686.pkg.tar.xz;;
-            x86_64) url=https://wingit.blob.core.windows.net/x86-64/$pkg-8.10.1-1-x86_64.pkg.tar.xz;;
-            esac
-            for suffix in '' .sig
-            do
-              curl --retry 5 -fLO $url$suffix || exit 1
-            done
-            pacman -U --noconfirm ${url##*/} || exit 1
-          done
-
-          # Sadly, this does not work because the Pacman repository's index only
-          # ever lists the latest package version:
-          # pacman -S --noconfirm libcurl=8.10.1-1 curl=8.10.1-1
-
       - name: Clone ${{ env.REPO }}
         shell: bash
         run: |


### PR DESCRIPTION
In the context of https://github.com/git-for-windows/git/issues/5401 ("Drop all i686 stuff from git-sdk-64"), this PR adjusts a few files so that the `build-and-deploy` workflow will run successfully in `git-sdk-32` (it currently runs in `git-sdk-64`, unlike when the `git-artifacts` builds `mingw-w64-i686-git`, where `git-sdk-32` is used already).

The `build-and-deploy` workflow will continue as before, as it will only make a difference when the `architecture` is set to `i686` or `x86_64` to build a MINGW package (and currently, the `architecture` is left empty for those).