### PR TITLE
init-g4w-sdk-for-pacman: work around caching issue

### DIFF
--- a/.github/actions/init-g4w-sdk-for-pacman/action.yml
+++ b/.github/actions/init-g4w-sdk-for-pacman/action.yml
@@ -20,7 +20,7 @@ runs:
           https://github.com/git-for-windows/git-sdk-64 .tmp &&
         rev="$(git -C .tmp rev-parse HEAD)" &&
         echo "rev=$rev" >>$GITHUB_OUTPUT &&
-        echo "cache-key=g4w-sdk-$rev${{ inputs.include-makepkg != 'false' && '+makepkg' || '' }}" >>$GITHUB_OUTPUT
+        echo "cache-key=g4w-sdk${{ inputs.include-makepkg != 'false' && '+makepkg' || '' }}-$rev" >>$GITHUB_OUTPUT
     - name: restore cached git-sdk-64 subset
       id: restore-g4w-sdk
       uses: actions/cache/restore@v4


### PR DESCRIPTION
actions/cache/restore [does a prefix match on the cache key to restore](https://github.com/actions/cache/issues/1433#issuecomment-2259294936). This can lead to restoring a different cache than we expect. In that case the cache-hit output is set to false, which further disturbs our workflows, since a cache was restored, but the output claims a cache miss.

To work around this, turn the makepkg suffix into an infix.