### PR TITLE
rebase-branch: recognize space-aligned Copilot stats trailer

### DIFF
--- a/rebase-branch.sh
+++ b/rebase-branch.sh
@@ -254,8 +254,9 @@ Your FINAL line must be exactly: skip <oid>, skip -- <reason>, continue -- <summ
 	echo "::endgroup::"
 
 	# Extract the decision from the last meaningful line.
-	# Copilot appends a stats trailer (key: value lines) after the actual
-	# output, separated by blank lines. The sed script finds the last
+	# Copilot appends a stats trailer after the actual output, separated
+	# by blank lines. The format may be "key: value" (colon-separated)
+	# or "Key   value" (space-aligned). The sed script finds the last
 	# decision keyword (continue/skip/fail) that is followed only by
 	# blank lines and stats-like lines until EOF.
 	decision=$(echo "$ai_output" | sed -n '
@@ -276,7 +277,10 @@ Your FINAL line must be exactly: skip <oid>, skip -- <reason>, continue -- <summ
 		/^$/b emptyloop
 		:stats
 		/[A-Za-z][^:]\{0,30\}:$/{ n; /^ /!b; :ind; ${ g; p; q }; n; /^ /b ind; b stats }
-		/^[^:]\{1,30\}: /!b
+		/^[^:]\{1,30\}: /b stats_line
+		/^[A-Za-z][A-Za-z]*  /b stats_line
+		b
+		:stats_line
 		${ g; p; q }
 		n
 		b stats


### PR DESCRIPTION
The [scheduled `rebase-shears` run](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/24401147325/job/71271793472) failed today with:

```
##[error]Unexpected AI decision '': 6c02c9d442 tests: use the correct path separator with BusyBox
##[error]Rebase failed for shears/seen
```

The AI (Copilot CLI with `claude-opus-4.6`) actually resolved the `t/test-lib.sh` conflict correctly and output a valid decision:

```
continue -- kept both HEAD's `set -e` and REBASE_HEAD's `PATH_SEP` block as independent additions
```

But the `sed` state machine that extracts this decision from the Copilot output returned empty. The parser validates that everything after the decision line is blank lines and stats-like trailer lines before accepting it. The trailer the Copilot CLI actually emits looks like this:

```
Changes   +1 -3
Requests  3 Premium (38s)
Tokens     127.5k  ↓ 1.5k  53.9k (cached)
```

These are space-aligned (word followed by 2+ spaces then value), but the `sed` script only recognized `key: value` lines (colon-separated). The stats lines were rejected, causing `sed` to discard the held decision and return nothing.

The fix adds a second pattern in the `:stats` section that matches lines starting with an alphabetic word followed by two or more spaces, alongside the existing colon-based recognizer.
