### PR TITLE
git-artifacts: restrict msys2-sync commit to mingw-w64-git/

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -325,7 +325,7 @@ jobs:
             git worktree add -b "$msys2_sync_branch" --no-checkout msys2-sync FETCH_HEAD &&
             git -C msys2-sync sparse-checkout set mingw-w64-git &&
             git -C msys2-sync checkout main -- mingw-w64-git &&
-            git -C msys2-sync commit -F - <<COMMIT_MSG &&
+            git -C msys2-sync commit -F - -- mingw-w64-git <<COMMIT_MSG &&
           mingw-w64-git: upgrade to Git for Windows $version
 
           This commit was created by:
@@ -334,7 +334,7 @@ jobs:
           See https://github.com/git-for-windows/git/releases/tag/$version for details.
           COMMIT_MSG
             echo "::notice::Created MSYS2 sync branch $msys2_sync_branch at $(git -C msys2-sync rev-parse HEAD)" &&
-            git worktree remove msys2-sync &&
+            git worktree remove -f msys2-sync &&
 
             git bundle create "$b"/MINGW-packages.bundle origin/main..main FETCH_HEAD.."$msys2_sync_branch"
           elif ! git update-index --ignore-submodules --refresh ||


### PR DESCRIPTION
The `git-artifacts.yml` workflow creates an MSYS2 sync branch as part of non-RC releases. This branch is based on `msys2/MINGW-packages`' `master` and carries the updated `mingw-w64-git/` package definition from Git for Windows.

During the v2.54.0 release, the [`git-artifacts` (x86_64) workflow run](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/24681595846) created the `msys2-sync-v2.54.0.windows.1` branch with a [bad commit](https://github.com/git-for-windows/MINGW-packages/commit/3d9fe42857a93235c2b58a069761c7cb28a261b2) that deleted every package directory other than `mingw-w64-git/`. The resulting [PR in msys2/MINGW-packages](https://github.com/msys2/MINGW-packages/pull/29080) therefore showed hundreds of spurious deletions and had to be [manually fixed up via force-push](https://github.com/git-for-windows/MINGW-packages/compare/3d9fe42857a93235c2b58a069761c7cb28a261b2...b8612a7df16deedf1045f5bb0bb22af02a824a39) before it could be merged.

**Root cause:** the worktree is created with `--no-checkout`, which leaves its index empty. `sparse-checkout set mingw-w64-git` restricts which paths are materialized in the working tree but does not populate the index. `checkout main -- mingw-w64-git` then stages only the `mingw-w64-git/` files. When `git commit` runs without a pathspec, it compares this sparse index against the parent (msys2's `master`, which contains all packages) and treats every path outside `mingw-w64-git/` as deleted.

**Fix:** add `-- mingw-w64-git` to the `git commit` command so that only changes inside that directory are committed, matching the pathspec already used by the preceding `checkout` command.
