### PR TITLE
git-artifacts: switch code signing to Azure Artifact Signing with OIDC

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -255,17 +255,25 @@ jobs:
               $(cat "$GITHUB_WORKSPACE"/bundle-artifacts/next_version)
           fi &&
           git reset --hard $(cat "$GITHUB_WORKSPACE"/bundle-artifacts/next_version)
-      - name: Prepare home directory for code-signing
+      - name: Set up code-signing with Azure Artifact Signing
         env:
-          CODESIGN_P12: ${{secrets.CODESIGN_P12}}
-          CODESIGN_PASS: ${{secrets.CODESIGN_PASS}}
-        if: env.CODESIGN_P12 != '' && env.CODESIGN_PASS != '' && steps.restore-cached-git-pkg.outputs.cache-hit != 'true'
+          AZURE_CLIENT_ID: ${{secrets.AZURE_CLIENT_ID}}
+          AZURE_CLIENT_SECRET: ${{secrets.AZURE_CLIENT_SECRET}}
+          AZURE_TENANT_ID: ${{secrets.AZURE_TENANT_ID}}
+          AZURE_SIGNING_ENDPOINT: ${{secrets.AZURE_SIGNING_ENDPOINT}}
+          AZURE_SIGNING_ACCOUNT: ${{secrets.AZURE_SIGNING_ACCOUNT}}
+          AZURE_SIGNING_CERTIFICATE_PROFILE: ${{secrets.AZURE_SIGNING_CERTIFICATE_PROFILE}}
+        if: env.AZURE_CLIENT_ID != '' && steps.restore-cached-git-pkg.outputs.cache-hit != 'true'
         run: |
-          cd home &&
-          mkdir -p .sig &&
-          echo -n "$CODESIGN_P12" | tr % '\n' | base64 -d >.sig/codesign.p12 &&
-          echo -n "$CODESIGN_PASS" >.sig/codesign.pass
-          git config --global alias.signtool '!sh "/usr/src/build-extra/signtool.sh"'
+          {
+            echo "AZURE_CLIENT_ID=$AZURE_CLIENT_ID"
+            echo "AZURE_CLIENT_SECRET=$AZURE_CLIENT_SECRET"
+            echo "AZURE_TENANT_ID=$AZURE_TENANT_ID"
+            echo "AZURE_SIGNING_ENDPOINT=$AZURE_SIGNING_ENDPOINT"
+            echo "AZURE_SIGNING_ACCOUNT=$AZURE_SIGNING_ACCOUNT"
+            echo "AZURE_SIGNING_CERTIFICATE_PROFILE=$AZURE_SIGNING_CERTIFICATE_PROFILE"
+          } >>$GITHUB_ENV &&
+          git config --global alias.signtool "!sh \"$PWD/azure-signtool.sh\""
       - name: Prepare home directory for GPG signing
         timeout-minutes: 5
         if: env.GPGKEY != '' && steps.restore-cached-git-pkg.outputs.cache-hit != 'true'
@@ -445,16 +453,25 @@ jobs:
               sed '/\.sig$/d;/archimport/d;/cvs/d;/p4/d;/gitweb/d;s/^/--pkg=/' |
               tr '\n' ' ')" >>$GITHUB_ENV &&
           echo "VERSION_OPT=--version=$(cat pkg-"$ARCHITECTURE"/ver)" >>$GITHUB_ENV
-      - name: Prepare home directory for code-signing
+      - name: Set up code-signing with Azure Artifact Signing
         env:
-          CODESIGN_P12: ${{secrets.CODESIGN_P12}}
-          CODESIGN_PASS: ${{secrets.CODESIGN_PASS}}
-        if: (matrix.artifact.name == 'installer' || matrix.artifact.name == 'portable') && env.CODESIGN_P12 != '' && env.CODESIGN_PASS != ''
+          AZURE_CLIENT_ID: ${{secrets.AZURE_CLIENT_ID}}
+          AZURE_CLIENT_SECRET: ${{secrets.AZURE_CLIENT_SECRET}}
+          AZURE_TENANT_ID: ${{secrets.AZURE_TENANT_ID}}
+          AZURE_SIGNING_ENDPOINT: ${{secrets.AZURE_SIGNING_ENDPOINT}}
+          AZURE_SIGNING_ACCOUNT: ${{secrets.AZURE_SIGNING_ACCOUNT}}
+          AZURE_SIGNING_CERTIFICATE_PROFILE: ${{secrets.AZURE_SIGNING_CERTIFICATE_PROFILE}}
+        if: (matrix.artifact.name == 'installer' || matrix.artifact.name == 'portable') && env.AZURE_CLIENT_ID != ''
         run: |
-          mkdir -p home/.sig &&
-          echo -n "$CODESIGN_P12" | tr % '\n' | base64 -d >home/.sig/codesign.p12 &&
-          echo -n "$CODESIGN_PASS" >home/.sig/codesign.pass &&
-          git config --global alias.signtool '!sh "/usr/src/build-extra/signtool.sh"'
+          {
+            echo "AZURE_CLIENT_ID=$AZURE_CLIENT_ID"
+            echo "AZURE_CLIENT_SECRET=$AZURE_CLIENT_SECRET"
+            echo "AZURE_TENANT_ID=$AZURE_TENANT_ID"
+            echo "AZURE_SIGNING_ENDPOINT=$AZURE_SIGNING_ENDPOINT"
+            echo "AZURE_SIGNING_ACCOUNT=$AZURE_SIGNING_ACCOUNT"
+            echo "AZURE_SIGNING_CERTIFICATE_PROFILE=$AZURE_SIGNING_CERTIFICATE_PROFILE"
+          } >>$GITHUB_ENV &&
+          git config --global alias.signtool "!sh \"$PWD/azure-signtool.sh\""
       - name: Build ${{env.ARCHITECTURE}} ${{matrix.artifact.name}}-mingit
         if: matrix.artifact.name == 'nuget'
         run: |

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -44,6 +44,10 @@ defaults:
 jobs:
   pkg:
     runs-on: ${{ github.event.inputs.architecture == 'aarch64' && 'windows-11-arm' || 'windows-latest' }}
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
     outputs:
       artifact_matrix: ${{ steps.artifact-build-matrix.outputs.result }}
       msystem: ${{steps.configure-environment.outputs.MSYSTEM}}
@@ -255,20 +259,24 @@ jobs:
               $(cat "$GITHUB_WORKSPACE"/bundle-artifacts/next_version)
           fi &&
           git reset --hard $(cat "$GITHUB_WORKSPACE"/bundle-artifacts/next_version)
+      - name: Azure Login (OIDC)
+        env:
+          AZURE_CLIENT_ID: ${{secrets.AZURE_CLIENT_ID}}
+        if: env.AZURE_CLIENT_ID != '' && steps.restore-cached-git-pkg.outputs.cache-hit != 'true'
+        uses: azure/login@v3
+        with:
+          client-id: ${{secrets.AZURE_CLIENT_ID}}
+          tenant-id: ${{secrets.AZURE_TENANT_ID}}
+          allow-no-subscriptions: true
       - name: Set up code-signing with Azure Artifact Signing
         env:
           AZURE_CLIENT_ID: ${{secrets.AZURE_CLIENT_ID}}
-          AZURE_CLIENT_SECRET: ${{secrets.AZURE_CLIENT_SECRET}}
-          AZURE_TENANT_ID: ${{secrets.AZURE_TENANT_ID}}
           AZURE_SIGNING_ENDPOINT: ${{secrets.AZURE_SIGNING_ENDPOINT}}
           AZURE_SIGNING_ACCOUNT: ${{secrets.AZURE_SIGNING_ACCOUNT}}
           AZURE_SIGNING_CERTIFICATE_PROFILE: ${{secrets.AZURE_SIGNING_CERTIFICATE_PROFILE}}
         if: env.AZURE_CLIENT_ID != '' && steps.restore-cached-git-pkg.outputs.cache-hit != 'true'
         run: |
           {
-            echo "AZURE_CLIENT_ID=$AZURE_CLIENT_ID"
-            echo "AZURE_CLIENT_SECRET=$AZURE_CLIENT_SECRET"
-            echo "AZURE_TENANT_ID=$AZURE_TENANT_ID"
             echo "AZURE_SIGNING_ENDPOINT=$AZURE_SIGNING_ENDPOINT"
             echo "AZURE_SIGNING_ACCOUNT=$AZURE_SIGNING_ACCOUNT"
             echo "AZURE_SIGNING_CERTIFICATE_PROFILE=$AZURE_SIGNING_CERTIFICATE_PROFILE"
@@ -386,6 +394,10 @@ jobs:
   artifacts:
     runs-on: ${{ github.event.inputs.architecture == 'aarch64' && 'windows-11-arm' || 'windows-latest' }}
     needs: pkg
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
     env:
       MSYSTEM: ${{ needs.pkg.outputs.msystem }}
       MINGW_PREFIX: ${{ needs.pkg.outputs.mingw-prefix }}
@@ -453,20 +465,24 @@ jobs:
               sed '/\.sig$/d;/archimport/d;/cvs/d;/p4/d;/gitweb/d;s/^/--pkg=/' |
               tr '\n' ' ')" >>$GITHUB_ENV &&
           echo "VERSION_OPT=--version=$(cat pkg-"$ARCHITECTURE"/ver)" >>$GITHUB_ENV
+      - name: Azure Login (OIDC)
+        env:
+          AZURE_CLIENT_ID: ${{secrets.AZURE_CLIENT_ID}}
+        if: (matrix.artifact.name == 'installer' || matrix.artifact.name == 'portable') && env.AZURE_CLIENT_ID != ''
+        uses: azure/login@v3
+        with:
+          client-id: ${{secrets.AZURE_CLIENT_ID}}
+          tenant-id: ${{secrets.AZURE_TENANT_ID}}
+          allow-no-subscriptions: true
       - name: Set up code-signing with Azure Artifact Signing
         env:
           AZURE_CLIENT_ID: ${{secrets.AZURE_CLIENT_ID}}
-          AZURE_CLIENT_SECRET: ${{secrets.AZURE_CLIENT_SECRET}}
-          AZURE_TENANT_ID: ${{secrets.AZURE_TENANT_ID}}
           AZURE_SIGNING_ENDPOINT: ${{secrets.AZURE_SIGNING_ENDPOINT}}
           AZURE_SIGNING_ACCOUNT: ${{secrets.AZURE_SIGNING_ACCOUNT}}
           AZURE_SIGNING_CERTIFICATE_PROFILE: ${{secrets.AZURE_SIGNING_CERTIFICATE_PROFILE}}
         if: (matrix.artifact.name == 'installer' || matrix.artifact.name == 'portable') && env.AZURE_CLIENT_ID != ''
         run: |
           {
-            echo "AZURE_CLIENT_ID=$AZURE_CLIENT_ID"
-            echo "AZURE_CLIENT_SECRET=$AZURE_CLIENT_SECRET"
-            echo "AZURE_TENANT_ID=$AZURE_TENANT_ID"
             echo "AZURE_SIGNING_ENDPOINT=$AZURE_SIGNING_ENDPOINT"
             echo "AZURE_SIGNING_ACCOUNT=$AZURE_SIGNING_ACCOUNT"
             echo "AZURE_SIGNING_CERTIFICATE_PROFILE=$AZURE_SIGNING_CERTIFICATE_PROFILE"

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -271,16 +271,10 @@ jobs:
       - name: Set up code-signing with Azure Artifact Signing
         env:
           AZURE_CLIENT_ID: ${{secrets.AZURE_CLIENT_ID}}
-          AZURE_SIGNING_ENDPOINT: ${{secrets.AZURE_SIGNING_ENDPOINT}}
-          AZURE_SIGNING_ACCOUNT: ${{secrets.AZURE_SIGNING_ACCOUNT}}
-          AZURE_SIGNING_CERTIFICATE_PROFILE: ${{secrets.AZURE_SIGNING_CERTIFICATE_PROFILE}}
+          AZURE_SIGNING_OPTS: ${{secrets.AZURE_SIGNING_OPTS}}
         if: env.AZURE_CLIENT_ID != '' && steps.restore-cached-git-pkg.outputs.cache-hit != 'true'
         run: |
-          {
-            echo "AZURE_SIGNING_ENDPOINT=$AZURE_SIGNING_ENDPOINT"
-            echo "AZURE_SIGNING_ACCOUNT=$AZURE_SIGNING_ACCOUNT"
-            echo "AZURE_SIGNING_CERTIFICATE_PROFILE=$AZURE_SIGNING_CERTIFICATE_PROFILE"
-          } >>$GITHUB_ENV &&
+          echo "AZURE_SIGNING_OPTS=$AZURE_SIGNING_OPTS" >>$GITHUB_ENV &&
           git config --global alias.signtool "!sh \"$PWD/azure-signtool.sh\""
       - name: Prepare home directory for GPG signing
         timeout-minutes: 5
@@ -477,16 +471,10 @@ jobs:
       - name: Set up code-signing with Azure Artifact Signing
         env:
           AZURE_CLIENT_ID: ${{secrets.AZURE_CLIENT_ID}}
-          AZURE_SIGNING_ENDPOINT: ${{secrets.AZURE_SIGNING_ENDPOINT}}
-          AZURE_SIGNING_ACCOUNT: ${{secrets.AZURE_SIGNING_ACCOUNT}}
-          AZURE_SIGNING_CERTIFICATE_PROFILE: ${{secrets.AZURE_SIGNING_CERTIFICATE_PROFILE}}
+          AZURE_SIGNING_OPTS: ${{secrets.AZURE_SIGNING_OPTS}}
         if: (matrix.artifact.name == 'installer' || matrix.artifact.name == 'portable') && env.AZURE_CLIENT_ID != ''
         run: |
-          {
-            echo "AZURE_SIGNING_ENDPOINT=$AZURE_SIGNING_ENDPOINT"
-            echo "AZURE_SIGNING_ACCOUNT=$AZURE_SIGNING_ACCOUNT"
-            echo "AZURE_SIGNING_CERTIFICATE_PROFILE=$AZURE_SIGNING_CERTIFICATE_PROFILE"
-          } >>$GITHUB_ENV &&
+          echo "AZURE_SIGNING_OPTS=$AZURE_SIGNING_OPTS" >>$GITHUB_ENV &&
           git config --global alias.signtool "!sh \"$PWD/azure-signtool.sh\""
       - name: Build ${{env.ARCHITECTURE}} ${{matrix.artifact.name}}-mingit
         if: matrix.artifact.name == 'nuget'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/node_modules/
+/package.json
+/package-lock.json
+/.sign-tool/

--- a/azure-signtool.sh
+++ b/azure-signtool.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+# Azure Artifact Signing wrapper for use as `git signtool`.
+#
+# This replaces the osslsigncode-based signtool.sh from build-extra,
+# using the pre-built sign tool from
+# https://github.com/dscho/prebuilt-dotnet-sign-tool instead.
+#
+# It expects the following environment variables:
+#   AZURE_CLIENT_ID                      - Azure AD app client ID
+#   AZURE_CLIENT_SECRET                  - Azure AD app client secret
+#   AZURE_TENANT_ID                      - Azure AD tenant ID
+#   AZURE_SIGNING_ENDPOINT               - Azure Artifact Signing endpoint URL
+#   AZURE_SIGNING_ACCOUNT                - Azure Artifact Signing account name
+#   AZURE_SIGNING_CERTIFICATE_PROFILE    - certificate profile name
+
+die () {
+	echo "$*" >&2
+	exit 1
+}
+
+# Locate the sign tool, downloading it if necessary
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SIGN_TOOL_DIR="$SCRIPT_DIR/.sign-tool"
+sign_exe="$SIGN_TOOL_DIR/sign"
+
+if ! test -x "$sign_exe" && ! test -x "$sign_exe.exe"
+then
+	echo "Downloading pre-built sign tool..." >&2
+	sysdir="${SYSTEMROOT:-${WINDIR:-/proc/fake-non-existent}}/System32" &&
+	mkdir -p "$SIGN_TOOL_DIR" &&
+	url="https://github.com/dscho/prebuilt-dotnet-sign-tool/releases/latest/download/sign-tool.zip" &&
+	zip_path="$SIGN_TOOL_DIR/sign-tool.zip" &&
+	"$sysdir/curl.exe" -sLo "$(cygpath -aw "$zip_path")" "$url" &&
+	"$sysdir/tar.exe" -xf "$(cygpath -aw "$zip_path")" -C "$(cygpath -aw "$SIGN_TOOL_DIR")" &&
+	rm -f "$zip_path" ||
+	die "Failed to download and extract sign tool"
+
+	test -x "$sign_exe" || test -x "$sign_exe.exe" ||
+	die "sign.exe not found in $SIGN_TOOL_DIR after extraction"
+fi
+
+s () {
+	"$sign_exe" code artifact-signing \
+		"$1" \
+		--description "Git for Windows" \
+		--description-url "https://gitforwindows.org" \
+		-v information \
+		--artifact-signing-endpoint "$AZURE_SIGNING_ENDPOINT" \
+		--artifact-signing-account "$AZURE_SIGNING_ACCOUNT" \
+		--artifact-signing-certificate-profile "$AZURE_SIGNING_CERTIFICATE_PROFILE"
+}
+
+for f in "$@"
+do
+	s "$f" || {
+		echo "Retrying after 5 seconds..." >&2
+		sleep 5 && s "$f" || {
+			sleep 10 && s "$f" || {
+				sleep 20 && s "$f" || {
+					sleep 40 && s "$f"
+				}
+			}
+		}
+	} || exit
+done

--- a/azure-signtool.sh
+++ b/azure-signtool.sh
@@ -6,10 +6,8 @@
 # using the pre-built sign tool from
 # https://github.com/dscho/prebuilt-dotnet-sign-tool instead.
 #
-# It expects the following environment variables:
-#   AZURE_CLIENT_ID                      - Azure AD app client ID
-#   AZURE_CLIENT_SECRET                  - Azure AD app client secret
-#   AZURE_TENANT_ID                      - Azure AD tenant ID
+# It expects the Azure CLI to be authenticated (via `azure/login` with
+# OIDC) and the following environment variables:
 #   AZURE_SIGNING_ENDPOINT               - Azure Artifact Signing endpoint URL
 #   AZURE_SIGNING_ACCOUNT                - Azure Artifact Signing account name
 #   AZURE_SIGNING_CERTIFICATE_PROFILE    - certificate profile name
@@ -43,6 +41,7 @@ fi
 s () {
 	"$sign_exe" code artifact-signing \
 		"$1" \
+		--azure-credential-type azure-cli \
 		--description "Git for Windows" \
 		--description-url "https://gitforwindows.org" \
 		-v information \

--- a/azure-signtool.sh
+++ b/azure-signtool.sh
@@ -7,10 +7,11 @@
 # https://github.com/dscho/prebuilt-dotnet-sign-tool instead.
 #
 # It expects the Azure CLI to be authenticated (via `azure/login` with
-# OIDC) and the following environment variables:
-#   AZURE_SIGNING_ENDPOINT               - Azure Artifact Signing endpoint URL
-#   AZURE_SIGNING_ACCOUNT                - Azure Artifact Signing account name
-#   AZURE_SIGNING_CERTIFICATE_PROFILE    - certificate profile name
+# OIDC) and the following environment variable:
+#   AZURE_SIGNING_OPTS - command-line arguments for the sign tool, e.g.
+#     --artifact-signing-endpoint <url>
+#     --artifact-signing-account <account>
+#     --artifact-signing-certificate-profile <profile>
 
 die () {
 	echo "$*" >&2
@@ -45,9 +46,7 @@ s () {
 		--description "Git for Windows" \
 		--description-url "https://gitforwindows.org" \
 		-v information \
-		--artifact-signing-endpoint "$AZURE_SIGNING_ENDPOINT" \
-		--artifact-signing-account "$AZURE_SIGNING_ACCOUNT" \
-		--artifact-signing-certificate-profile "$AZURE_SIGNING_CERTIFICATE_PROFILE"
+		$AZURE_SIGNING_OPTS
 }
 
 for f in "$@"


### PR DESCRIPTION
The current code signing certificate (used via `osslsigncode` and build-extra's `signtool.sh`) is expiring very soon. Unfortunately, renewing the certificate would be prohibitively expensive. There was a price hike (from $247.50 for three years to $345 per year), mainly due to the fact that now this code-signing method would require a hardware dongle, which incidentally is also incompatible with the way we currently build: we cannot just plug in a USB dongle into the cloud.

This PR switches to [Azure Artifact Signing](https://learn.microsoft.com/en-us/azure/trusted-signing/overview) using the [`dotnet/sign`](https://github.com/dotnet/sign) CLI, authenticating via OIDC rather than static secrets, nicely side-stepping both blockers.

### Why Azure Artifact Signing?

Cloud-managed certificates eliminate the need to handle private key material in CI. The signing key lives in an Hardware Security Module ("HSM"), and access is controlled through Azure Role-Based Access Control ("RBAC").

Concretely, this means that the authorization is keyed on the GitHub workflow running on the `main` branch. Even if a secret should leak, the blast radius is therefore very small.

### Why the pre-built sign tool?

The `dotnet/sign` project currently lacks native ARM64 support ([dotnet/sign#852](https://github.com/dotnet/sign/issues/852)). A [pre-built x64 `sign.exe`](https://github.com/dscho/prebuilt-dotnet-sign-tool/releases) (with bundled .NET runtime) runs fine under emulation on `windows-11-arm` runners, covering all three architectures from one tool.

### What changes

The new `azure-signtool.sh` is a drop-in replacement for build-extra's `signtool.sh`. It auto-downloads the sign tool on first use and preserves the same retry/backoff logic. The `git signtool` alias is pointed at this wrapper, so `please.sh` and the explicit Portable Git signing call work without further changes.

Authentication uses [OIDC workload identity federation](https://docs.github.com/en/actions/concepts/security/openid-connect) (`azure/login@v3` + `--azure-credential-type azure-cli`) instead of a static client secret. This means no long-lived credentials are stored in GitHub secrets at all; Azure only trusts short-lived tokens from this specific repository.

### Required secrets

| Secret | Purpose |
|---|---|
| `AZURE_CLIENT_ID` | App registration's Application (client) ID |
| `AZURE_TENANT_ID` | Azure AD tenant ID |
| `AZURE_SIGNING_OPTS` | Sign tool arguments, e.g. `--artifact-signing-endpoint <url> --artifact-signing-account <acct> --artifact-signing-certificate-profile <profile>` |

The Azure-side setup (app registration, federated credential, RBAC role assignment) is documented in the second commit's message, and I have already confirmed that it works, via [this `git-artifacts` run](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/24876848095) (which did pick up a previously-built `mingw-64-git` package, but did code-sign the installer with my new certificate).