### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/actions/check-run-action/action.yml
+++ b/.github/actions/check-run-action/action.yml
@@ -37,7 +37,7 @@ runs:
   steps:
     - name: Create or update the Check Run
       id: check-run
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       env:
         APP_ID: ${{ inputs.app-id }}
         PRIVATE_KEY: ${{ inputs.private-key }}

--- a/.github/actions/gitforwindows.org/action.yml
+++ b/.github/actions/gitforwindows.org/action.yml
@@ -24,7 +24,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: release
     - name: Mirror Check Run to ${{ inputs.owner }}/${{ inputs.repo }}

--- a/.github/actions/gitforwindows.org/action.yml
+++ b/.github/actions/gitforwindows.org/action.yml
@@ -42,7 +42,7 @@ runs:
         details-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}}"
     - name: Update gitforwindows.org
       if: ${{ !contains(inputs.display-version, '-rc') }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       env:
         GIT_CONFIG_PARAMETERS: "'user.name=gitforwindowshelper-bot' 'user.email=gitforwindowshelper-bot@users.noreply.github.com'"
       with:

--- a/.github/actions/github-release/action.yml
+++ b/.github/actions/github-release/action.yml
@@ -72,7 +72,7 @@ runs:
         text: "For details, see [this run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}})."
         details-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}}"
     - name: Download bundle-artifacts (needed to push the tag)
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: bundle-artifacts
         path: bundle-artifacts

--- a/.github/actions/github-release/action.yml
+++ b/.github/actions/github-release/action.yml
@@ -77,7 +77,7 @@ runs:
         name: bundle-artifacts
         path: bundle-artifacts
     - name: create release and upload release assets
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       id: release
       with:
         script: |
@@ -165,7 +165,7 @@ runs:
           core.setOutput('token', state.accessToken)
     - name: Add a comment about the announcement email to the Pull Request
       if: inputs.pull-request-number != ''
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         github-token: ${{ steps.release.outputs.token }}
         script: |

--- a/.github/actions/github-release/action.yml
+++ b/.github/actions/github-release/action.yml
@@ -55,7 +55,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: release
     - name: Mirror Check Run to ${{ inputs.owner }}/${{ inputs.repo }}

--- a/.github/actions/init-g4w-sdk-for-pacman/action.yml
+++ b/.github/actions/init-g4w-sdk-for-pacman/action.yml
@@ -23,7 +23,7 @@ runs:
         echo "cache-key=g4w-sdk${{ inputs.include-makepkg != 'false' && '+makepkg' || '' }}-$rev" >>$GITHUB_OUTPUT
     - name: restore cached git-sdk-64 subset
       id: restore-g4w-sdk
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       env:
         cache-name: cache-g4w-sdk
       with:
@@ -94,7 +94,7 @@ runs:
         }
     - name: cache git-sdk-64 subset
       if: ${{ steps.restore-g4w-sdk.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       env:
         cache-name: cache-g4w-sdk
       with:

--- a/.github/actions/mail-announcement/action.yml
+++ b/.github/actions/mail-announcement/action.yml
@@ -59,7 +59,7 @@ runs:
         sudo apt-get update &&
         sudo apt-get -y install libnet-ssleay-perl git-email
     - name: Send announcement email
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const mbox = ${{ toJSON(inputs.announcement) }}

--- a/.github/actions/mail-announcement/action.yml
+++ b/.github/actions/mail-announcement/action.yml
@@ -36,7 +36,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: release
     - name: Mirror Check Run to ${{ inputs.owner }}/${{ inputs.repo }}

--- a/.github/actions/nuget-packages/action.yml
+++ b/.github/actions/nuget-packages/action.yml
@@ -53,7 +53,7 @@ runs:
         text: "For details, see [this run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}})."
         details-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}}"
     - name: Download the NuGet packages
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const [ artifactsOwner, artifactsRepo ] = '${{ inputs.artifacts-repository }}'.split('/')

--- a/.github/actions/nuget-packages/action.yml
+++ b/.github/actions/nuget-packages/action.yml
@@ -36,7 +36,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: release
     - name: Mirror Check Run to ${{ inputs.owner }}/${{ inputs.repo }}

--- a/.github/actions/nuget-packages/action.yml
+++ b/.github/actions/nuget-packages/action.yml
@@ -66,7 +66,7 @@ runs:
             ${{ inputs.git_artifacts_x86_64_workflow_run_id }},
             'nuget-x86_64'
           )
-    - uses: nuget/setup-nuget@v2
+    - uses: nuget/setup-nuget@v3
     - name: Upload NuGet packages
       shell: bash
       run: |

--- a/.github/actions/pacman-packages/action.yml
+++ b/.github/actions/pacman-packages/action.yml
@@ -48,7 +48,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: release
     - name: Mirror Check Run to ${{ inputs.owner }}/${{ inputs.repo }}

--- a/.github/actions/pacman-packages/action.yml
+++ b/.github/actions/pacman-packages/action.yml
@@ -122,7 +122,7 @@ runs:
         info="$(gpg --list-keys --with-colons "${GPGKEY%% *}" | cut -d : -f 1,10 | sed -n '/^uid/{s|uid:||p;q}')" &&
         git config --global user.name "${info% <*}" &&
         git config --global user.email "<${info#*<}"
-    - uses: actions/create-github-app-token@v1
+    - uses: actions/create-github-app-token@v3
       id: pacman-repo-token
       with:
         app-id: ${{ inputs.app-id }}

--- a/.github/actions/pacman-packages/action.yml
+++ b/.github/actions/pacman-packages/action.yml
@@ -65,7 +65,7 @@ runs:
         text: "For details, see [this run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}})."
         details-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}}"
     - name: Download artifacts
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const [ artifactsOwner, artifactsRepo ] = '${{ inputs.artifacts-repository }}'.split('/')

--- a/.github/actions/repository-updates/action.yml
+++ b/.github/actions/repository-updates/action.yml
@@ -57,7 +57,7 @@ runs:
         path: bundle-artifacts
     - name: Update repositories
       if: ${{ !contains(inputs.display-version, '-rc') }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       env:
         GIT_CONFIG_PARAMETERS: "'user.name=gitforwindowshelper-bot' 'user.email=gitforwindowshelper-bot@users.noreply.github.com'"
       with:

--- a/.github/actions/repository-updates/action.yml
+++ b/.github/actions/repository-updates/action.yml
@@ -33,7 +33,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: release
     - name: Mirror Check Run to ${{ inputs.owner }}/${{ inputs.repo }}

--- a/.github/actions/repository-updates/action.yml
+++ b/.github/actions/repository-updates/action.yml
@@ -50,7 +50,7 @@ runs:
         text: "For details, see [this run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}})."
         details-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}}"
     - name: Download bundle-artifacts (needed to push the `main` branch)
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       if: ${{ !contains(inputs.display-version, '-rc') }}
       with:
         name: bundle-artifacts

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Identify actor
         id: actor
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const githubApiRequest = require('./github-api-request')

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -81,7 +81,7 @@ jobs:
           echo "GIT_REV=$(git rev-parse --verify "refs/tags/$EXISTING_GIT_TAG"^0)" >>$GITHUB_ENV
       - name: wait if workflow run has not finished yet
         if: env.TAG_GIT_WORKFLOW_RUN_ID != ''
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const { waitForWorkflowRunToFinish } = require('./workflow-runs')
@@ -93,7 +93,7 @@ jobs:
               process.env.TAG_GIT_WORKFLOW_RUN_ID
             )
       - name: Get bundle-artifacts download URL
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         if: env.TAG_GIT_WORKFLOW_RUN_ID != ''
         id: get-bundle-artifacts-url
         with:
@@ -189,7 +189,7 @@ jobs:
           flavor: build-installers
           architecture: ${{env.architecture}}
       - name: Create artifact build matrix
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         id: artifact-build-matrix
         with:
           script: |
@@ -520,7 +520,7 @@ jobs:
           repositories: ${{ env.REPO }}
       - name: Add a PR comment suggesting to validate the installer manually
         if: matrix.artifact.name == 'installer' && github.event.inputs.architecture == 'x86_64'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.pr-comment-token.outputs.token }}
           script: |
@@ -613,7 +613,7 @@ jobs:
     needs: ['pkg', 'artifacts']
     steps:
       - name: gather all SHA-256 checksums
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           SHA256SUMS: ${{ toJSON(needs.artifacts.outputs) }}
         with:

--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -55,7 +55,7 @@ jobs:
         # act as that App in repository secrets `GH_APP_ID`, `GH_APP_PRIVATE_KEY`.
       - name: Obtain installation token
         id: setup
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const appId = ${{ secrets.GH_APP_ID }}
@@ -89,7 +89,7 @@ jobs:
           git clone --depth 1 --single-branch -b main "https://github.com/$OWNER/$REPO" "/usr/src/$REPO"
       - name: Identify actor
         id: actor
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const githubApiRequest = require('./github-api-request')
@@ -165,7 +165,7 @@ jobs:
           git -c http.extraHeader="Authorization: Basic $auth" push --force origin HEAD:refs/heads/$PACKAGE_TO_UPGRADE-$UPGRADE_TO_VERSION
       - name: open PR
         if: steps.update.outputs.modified == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.setup.outputs.token }}
           script: |

--- a/.github/workflows/prepare-embargoed-branches.yml
+++ b/.github/workflows/prepare-embargoed-branches.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: identify actor
         id: actor
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const githubApiRequest = require('./github-api-request')
@@ -45,7 +45,7 @@ jobs:
           git config --global credential.helper '' &&
           git config --global --add credential.helper cache
       - name: configure push token
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const { callGit, getPushAuthorizationHeader } = require('./repository-updates.js')

--- a/.github/workflows/rebase-shears.yml
+++ b/.github/workflows/rebase-shears.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check if rebase is needed
         id: precheck
         if: github.event_name == 'schedule'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             // To avoid expensive clones when nothing changed, each run records
@@ -119,7 +119,7 @@ jobs:
 
       - name: Record ref state
         if: env.REF_STATE
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             let refState = process.env.REF_STATE

--- a/.github/workflows/release-git.yml
+++ b/.github/workflows/release-git.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: The `release` branch must be up to date
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const sha = await (async () => {
@@ -82,7 +82,7 @@ jobs:
             }
       - name: Get bundle-artifacts and sha256sums
         id: bundle-artifacts
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const { downloadBundleArtifacts } = require('./github-release')
@@ -119,7 +119,7 @@ jobs:
           path: bundle-artifacts/announce-*
       - name: Prepare a comment about the announcement email to the Pull Request
         id: announcement
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const gitSHA = ${{ toJson(steps.bundle-artifacts.outputs.git-rev) }}

--- a/.github/workflows/tag-git.yml
+++ b/.github/workflows/tag-git.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: 'Determine tip commit'
         if: env.REV == 'main'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             if (process.env.SNAPSHOT === '') throw new Error(`Non-snapshot build on the 'main' branch is not supported.`)

--- a/.github/workflows/updpkgsums.yml
+++ b/.github/workflows/updpkgsums.yml
@@ -37,7 +37,7 @@ jobs:
         # act as that App in repository secrets `GH_APP_ID`, `GH_APP_PRIVATE_KEY`.
       - name: Obtain installation token
         id: setup
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const appId = ${{ secrets.GH_APP_ID }}
@@ -78,7 +78,7 @@ jobs:
           echo "result=$(cygpath -aw "/usr/src/$REPO")" >>$GITHUB_OUTPUT
       - name: Determine modified packages
         id: determine-packages
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           WORKTREE_PATH: '${{ steps.clone.outputs.result }}'
         with:
@@ -104,7 +104,7 @@ jobs:
       - name: Identify actor
         if: steps.determine-packages.outputs.result != ''
         id: actor
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const githubApiRequest = require('./github-api-request')
@@ -175,7 +175,7 @@ jobs:
         # out where "there" is.
         if: steps.update.outputs.modified == 'true'
         id: determine-repository
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const githubApiRequest = require('./github-api-request')

--- a/.github/workflows/upload-snapshot.yml
+++ b/.github/workflows/upload-snapshot.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: download `bundle-artifacts`
         id: bundle-artifacts
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const {
@@ -95,7 +95,7 @@ jobs:
           details-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}}"
       - name: download remaining artifacts
         id: download-artifacts
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const {
@@ -148,7 +148,7 @@ jobs:
           append-text: 'Downloaded all artifacts'
       - name: validate
         id: validate
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs')
@@ -175,7 +175,7 @@ jobs:
             }
       - name: configure token
         id: snapshots-token
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           result-encoding: string
           script: |
@@ -196,7 +196,7 @@ jobs:
             ]))
             return Buffer.from(header.replace(/^Authorization: Basic /, ''), 'base64').toString('utf-8').replace(/^PAT:/, '')
       - name: figure out if we need to push commits
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             // Since `git-snapshots` is a fork, and forks share the same object store, we can
@@ -249,7 +249,7 @@ jobs:
           path: gh-pages
           token: ${{ steps.snapshots-token.outputs.result }}
       - name: update index.html
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const urlPrefix = `${{ github.server_url }}/${{ env.OWNER }}/${{ env.SNAPSHOTS_REPO }}/releases/download/${{ steps.bundle-artifacts.outputs.ver }}/`


### PR DESCRIPTION
The composite actions in `.github/actions/` lagged behind the workflow
files, still referencing older major versions of several GitHub Actions.
This brings everything up to the latest releases.

The upgrades, in order:

1. `actions/checkout` v4 to v6 (composite actions only; workflows
   already used v6). Brings Node.js 24 and improved credential
   security.

2. `actions/create-github-app-token` v1 to v3 (pacman-packages
   composite action only). Brings Node.js 24; removes custom proxy
   handling in favor of `NODE_USE_ENV_PROXY=1`.

3. `actions/cache` v4 to v5 (init-g4w-sdk-for-pacman composite action
   only). Pure Node.js 24 runtime migration.

4. `nuget/setup-nuget` v2 to v3 (nuget-packages composite action
   only). Node.js 24 and ESM migration; same inputs/outputs.

5. `actions/download-artifact` v4 to v8 (composite actions only;
   workflows already used v8). Adds unzipped artifact support and
   defaults hash-mismatch checks to error.

6. `actions/github-script` v7 to v9 (composite actions) and v8 to v9
   (workflow files). Upgrades @actions/github to v9 (ESM-only) and
   adds `getOctokit` factory to script context. This is the
   highest-risk upgrade due to the major version jump, but none of
   the scripts in this repository use `require('@actions/github')` or
   `getOctokit`, so the breaking changes do not apply here.

Actions already at their latest version and needing no changes:
`actions/upload-artifact@v7`, `actions/setup-node@v6`, and
`git-for-windows/setup-git-for-windows-sdk@v1`.

