### PR TITLE
Fix `msys2-runtime` version detection once again

### DIFF
--- a/update-scripts/version/msys2-runtime
+++ b/update-scripts/version/msys2-runtime
@@ -77,6 +77,15 @@ git --git-dir=msys2-runtime reset --soft "$revision" && {
 	git --git-dir=msys2-runtime worktree add --no-checkout src/msys2-runtime
 } &&
 
+# update-patches.sh needs the revision and base tag in src/msys2-runtime;
+# set up alternates so it can borrow objects from the bare repo
+echo "../../../../msys2-runtime/objects" \
+	>src/msys2-runtime/.git/objects/info/alternates &&
+git -C src/msys2-runtime update-ref HEAD "$revision" &&
+git -C src/msys2-runtime update-ref \
+	"refs/tags/cygwin-$pkgver" \
+	"$(git --git-dir=msys2-runtime rev-parse "refs/tags/cygwin-$pkgver")" &&
+
 sh -x ./update-patches.sh &&
 if test -n "$update_pkgver"
 then

--- a/update-scripts/version/msys2-runtime
+++ b/update-scripts/version/msys2-runtime
@@ -68,8 +68,10 @@ git --git-dir=msys2-runtime -c fetch.negotiationAlgorithm=noop fetch g4w \
         sort |
         uniq) &&
 
-git --git-dir=msys2-runtime reset --soft "$revision" &&
-git --git-dir=msys2-runtime worktree add --no-checkout src/msys2-runtime &&
+git --git-dir=msys2-runtime reset --soft "$revision" && {
+	test -d src/msys2-runtime ||
+	git --git-dir=msys2-runtime worktree add --no-checkout src/msys2-runtime
+} &&
 
 sh -x ./update-patches.sh &&
 if test -n "$update_pkgver"

--- a/update-scripts/version/msys2-runtime
+++ b/update-scripts/version/msys2-runtime
@@ -46,9 +46,13 @@ previous_commit="$(cat msys2-runtime.commit)" && {
 
 # update pkgver if needed
 update_pkgver= &&
-pkgver=$(git --git-dir=msys2-runtime describe --match='cygwin-[0-9]*' "$revision") &&
-pkgver=${pkgver#cygwin-} &&
-pkgver=${pkgver%%-*} &&
+pkgver=$(git --git-dir=msys2-runtime for-each-ref \
+    --format='%(refname:short) %(ahead-behind:'"$revision"')' \
+    --sort='ahead-behind:'"$revision" \
+    'refs/tags/cygwin-[0-9]*' |
+    sed -n 's/^cygwin-\([0-9][0-9.]*\) 0 .*/\1/p' |
+    head -n 1) &&
+test -n "$pkgver" &&
 if test "$pkgver" != "$(sed -n 's/^pkgver=\(.*\)/\1/p' PKGBUILD)"
 then
     update_pkgver=t


### PR DESCRIPTION
When I tried to `/open-pr` [the MSYS2-packages PR to update to Cygwin runtime v3.6.9](https://github.com/git-for-windows/MSYS2-packages/pull/285), it once again failed to determine the correct version. Instead of 3.6.9-1, it thought that I wanted to deploy 3.6.7-5.

The fix requires https://github.com/git-for-windows/MSYS2-packages/pull/285/commits/01bfb787985933f5e1c01e7f90311d35f348cf8e, and the corresponding change in `git-for-windows-automation`. This PR sports that change, along with two more fixes for issues I noticed while trying to reproduce the original issue.