### PR TITLE
Upgrade setup-git-for-windows-sdk to v2 and setup-nuget to v4

### DIFF
--- a/.github/actions/nuget-packages/action.yml
+++ b/.github/actions/nuget-packages/action.yml
@@ -66,7 +66,7 @@ runs:
             ${{ inputs.git_artifacts_x86_64_workflow_run_id }},
             'nuget-x86_64'
           )
-    - uses: nuget/setup-nuget@v3
+    - uses: nuget/setup-nuget@v4
     - name: Upload NuGet packages
       shell: bash
       run: |

--- a/.github/actions/pacman-packages/action.yml
+++ b/.github/actions/pacman-packages/action.yml
@@ -97,7 +97,7 @@ runs:
             'pkg-aarch64'
           )
     - name: Download Git for Windows SDK
-      uses: git-for-windows/setup-git-for-windows-sdk@v1
+      uses: git-for-windows/setup-git-for-windows-sdk@v2
       with:
         flavor: build-installers
         architecture: x86_64

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -98,7 +98,7 @@ jobs:
           fi
 
       - name: Download Git for Windows SDK
-        uses: git-for-windows/setup-git-for-windows-sdk@v1
+        uses: git-for-windows/setup-git-for-windows-sdk@v2
         id: setup-sdk
         with:
           flavor: ${{ env.PACKAGE_TO_BUILD == 'mingw-w64-git' && 'build-installers' || 'full' }}

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -188,7 +188,7 @@ jobs:
           git config --global user.name "$USER_NAME" &&
           git config --global user.email "$USER_EMAIL" &&
           echo "PACKAGER=$USER_NAME <$USER_EMAIL>" >> $GITHUB_ENV
-      - uses: git-for-windows/setup-git-for-windows-sdk@v1
+      - uses: git-for-windows/setup-git-for-windows-sdk@v2
         with:
           flavor: build-installers
           architecture: ${{env.architecture}}
@@ -421,7 +421,7 @@ jobs:
         with:
           name: bundle-artifacts
           path: bundle-artifacts
-      - uses: git-for-windows/setup-git-for-windows-sdk@v1
+      - uses: git-for-windows/setup-git-for-windows-sdk@v2
         with:
           flavor: build-installers
           architecture: ${{env.ARCHITECTURE}}

--- a/.github/workflows/remove-packages-from-pacman-repository.yml
+++ b/.github/workflows/remove-packages-from-pacman-repository.yml
@@ -31,7 +31,7 @@ jobs:
           mkdir -p "$HOME"
 
       - name: Download Git for Windows SDK
-        uses: git-for-windows/setup-git-for-windows-sdk@v1
+        uses: git-for-windows/setup-git-for-windows-sdk@v2
         with:
           flavor: build-installers
 


### PR DESCRIPTION
This upgrades two GitHub Actions to their latest major versions:

- `setup-git-for-windows-sdk` v1 to v2: the only change is the
  Node.js runtime bump from 20 to 24, silencing the deprecation
  warnings. All inputs, defaults, and behavior are unchanged.

- `nuget/setup-nuget` v3 to v4: the `action.yml` is identical
  between v3 and v4 (both already declared node24). The changes
  are purely internal (ESM migration, dependency updates).

All other external actions (`checkout@v6`, `github-script@v9`,
`upload-artifact@v7`, `download-artifact@v8`, `cache@v5`,
`create-github-app-token@v3`, `setup-node@v6`, `azure/login@v3`)
are already at their current major version.
