### PR TITLE
git-artifacts: pass GITHUB_TOKEN to bundle_pdbs

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -517,6 +517,8 @@ jobs:
           echo EOF >>$GITHUB_OUTPUT
       - name: Copy package-versions and pdbs (installer)
         if: matrix.artifact.name == 'installer'
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           cp /usr/src/build-extra/installer/package-versions.txt artifacts/ &&
           a=$PWD/artifacts &&


### PR DESCRIPTION
As pointed out in
https://github.com/git-for-windows/build-extra/pull/695#issuecomment-4439783978,
we still need to adapt git-for-windows-automation to avoid rate-limiting.
