### PR TITLE
innosetup version script: use GitHub Releases URL

### DIFF
--- a/update-scripts/version/innosetup
+++ b/update-scripts/version/innosetup
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 set -x &&
-url="https://jrsoftware.org/download.php/innosetup-$1.exe" &&
+version_underscores="$(echo "$1" | tr . _)" &&
+url="https://github.com/jrsoftware/issrc/releases/download/is-$version_underscores/innosetup-$1.exe" &&
 curl -# -LR -D curl.log -o is.exe "$url" &&
 cat curl.log &&
 grep 'HTTP/.* 200' curl.log &&


### PR DESCRIPTION
As of v6.7.3, it seems that the previous download URL format [no longer works](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/26465206376/job/77923505703), so we have to adapt. [Here](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/26466242248/job/77927187668) is a run that proves that this change works (it opened https://github.com/git-for-windows/build-extra/pull/702).