### PR TITLE
build-and-deploy: prepare for UCRT64 packages

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -249,12 +249,12 @@ jobs:
           MINGW_ARCHS_TO_BUILD=$(
                     case "$ARCHITECTURE,$PACKAGE_TO_BUILD" in
                     aarch64,*) echo "clangarm64";;
-                    x86_64,*) echo "mingw64";;
+                    x86_64,*) echo "mingw64 ucrt64";;
                     i686,*) echo "mingw32";;
-                    ,mingw-w64-wintoast) echo "mingw32 mingw64 clangarm64";; # We're (cross-)compiling via Visual Studio
-                    ,mingw-w64-git-credential-manager) echo "mingw32 mingw64 clangarm64";; # We're downloading the pre-built artifacts for all three platforms
-                    ,mingw-w64-git-lfs) echo "mingw32 mingw64 clangarm64";; # We're downloading the pre-built artifacts from Git LFS' official release page
-                    ,*) echo "mingw32 mingw64";;
+                    ,mingw-w64-wintoast) echo "mingw32 mingw64 ucrt64 clangarm64";; # We're (cross-)compiling via Visual Studio
+                    ,mingw-w64-git-credential-manager) echo "mingw32 mingw64 ucrt64 clangarm64";; # We're downloading the pre-built artifacts for all three platforms
+                    ,mingw-w64-git-lfs) echo "mingw32 mingw64 ucrt64 clangarm64";; # We're downloading the pre-built artifacts from Git LFS' official release page
+                    ,*) echo "mingw32 mingw64 ucrt64";;
                     esac
           )
 


### PR DESCRIPTION
More prep work for https://github.com/git-for-windows/git/issues/3167.
Depends on https://github.com/git-for-windows/build-extra/pull/705, https://github.com/git-for-windows/build-extra/pull/706 and probably some PRs against https://github.com/git-for-windows/MINGW-packages that haven't been written yet.