### PR TITLE
Fix `/open pr` for msys2-runtime

### DIFF
--- a/update-scripts/version/msys2-runtime
+++ b/update-scripts/version/msys2-runtime
@@ -77,14 +77,29 @@ git --git-dir=msys2-runtime reset --soft "$revision" && {
 	git --git-dir=msys2-runtime worktree add --no-checkout src/msys2-runtime
 } &&
 
-# update-patches.sh needs the revision and base tag in src/msys2-runtime;
-# set up alternates so it can borrow objects from the bare repo
-echo "../../../../msys2-runtime/objects" \
-	>src/msys2-runtime/.git/objects/info/alternates &&
-git -C src/msys2-runtime update-ref HEAD "$revision" &&
-git -C src/msys2-runtime update-ref \
-	"refs/tags/cygwin-$pkgver" \
-	"$(git --git-dir=msys2-runtime rev-parse "refs/tags/cygwin-$pkgver")" &&
+# When `src/msys2-runtime` was just created as a worktree of the bare
+# `msys2-runtime` repository (above), its `.git` is a gitfile pointer,
+# and both the object database and `refs/tags/*` are already shared with
+# the bare repo, while its HEAD has been initialized to $revision (which
+# the bare repo's HEAD was reset to right before the `worktree add`).
+# In that case, nothing more is needed before invoking update-patches.sh.
+#
+# However, when `src/msys2-runtime` pre-exists as an independent clone
+# (e.g. a developer's playground), its `.git` is a real directory, its
+# object database is independent of the bare repo, and its refs are not
+# shared. To let update-patches.sh find the target revision and the
+# base tag, borrow the objects via an alternates file (using a relative
+# path so both `/usr/bin/git.exe` and `/mingw64/bin/git.exe` can resolve
+# it) and sync HEAD and the base tag from the bare repo.
+if test -d src/msys2-runtime/.git
+then
+	echo "../../../../msys2-runtime/objects" \
+		>src/msys2-runtime/.git/objects/info/alternates &&
+	git -C src/msys2-runtime update-ref HEAD "$revision" &&
+	git -C src/msys2-runtime update-ref \
+		"refs/tags/cygwin-$pkgver" \
+		"$(git --git-dir=msys2-runtime rev-parse "refs/tags/cygwin-$pkgver")"
+fi &&
 
 sh -x ./update-patches.sh &&
 if test -n "$update_pkgver"


### PR DESCRIPTION
Any `/open pr` invocation for `msys2-runtime` after 305e4a8 (msys2-runtime: sync revision and base tag into src/msys2-runtime, 2026-04-24) would die at the same line:

```
src/msys2-runtime/.git/objects/info/alternates: Not a directory
```

I did not need this functionality and therefore did not see that breakage until [run 27062769399](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/27062769399/job/79878324139#step:9:798) came around.

The cause is that 305e4a8 added an unconditional block writing to `src/msys2-runtime/.git/objects/info/alternates`, but `src/msys2-runtime` is created in the immediately preceding lines via `git worktree add --no-checkout`, which leaves `.git` as a gitfile pointer rather than a directory. The commit message of 305e4a8 explicitly described `src/msys2-runtime` as "an independent clone, not a worktree", which matches a maintainer's local playground but never the CI environment.

In the worktree case none of the three operations are needed: the object database and `refs/tags/*` are shared with the bare `msys2-runtime` repo via the standard worktree refs split, and the worktree's HEAD was initialized to `$revision` by `git worktree add` because the bare repo's HEAD had just been pointed there by `git reset --soft`. The independent-clone case (the maintainer's playground, where `.git` is a real directory) still benefits from the alternates+update-ref dance, so this PR guards the entire block on `test -d src/msys2-runtime/.git` instead of removing it outright.

I considered reverting 305e4a8 wholesale, since the playground path has never been exercised in CI either, but the conditional is the lower-risk option that preserves both code paths.

I validated the fix end-to-end against the failing revision by hard-coding the inputs in a throwaway commit on the topic branch (since dropped). [Run 27066877451](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/27066877451) completed in roughly one minute and successfully opened [git-for-windows/MSYS2-packages#291](https://github.com/git-for-windows/MSYS2-packages/pull/291) with the expected shape (PKGBUILD bump, `msys2-runtime.commit` bump, one dropped and two added patches).