### PR TITLE
drop-pacman-package: support MINGW packages and UCRT64

### DIFF
--- a/.github/workflows/drop-pacman-package.yml
+++ b/.github/workflows/drop-pacman-package.yml
@@ -26,6 +26,9 @@ jobs:
         sdk:
           - name: git-sdk-64
             mingw-package-prefix: mingw-w64-x86_64
+          - name: git-sdk-64
+            ref: ucrt64
+            mingw-package-prefix: mingw-w64-ucrt-x86_64
           - name: git-sdk-arm64
             mingw-package-prefix: mingw-w64-clang-aarch64
           - name: git-sdk-32
@@ -51,6 +54,7 @@ jobs:
           persist-credentials: true
           repository: ${{ github.repository_owner }}/${{ matrix.sdk.name }}
           token: ${{ steps.sdk-repo-token.outputs.token }}
+          ref: ${{ matrix.sdk.ref }}
       - name: use the SDK's Bash and git.exe
         run: "usr\\bin\\bash.exe -lc 'cygpath -aw /usr/bin >>$GITHUB_PATH && cygpath -aw /cmd >>$GITHUB_PATH'"
       - name: Remove ${{ env.PACKAGE }}
@@ -93,7 +97,7 @@ jobs:
             gh pr create \
               --fill \
               --head "$branch" \
-              --base main 2>&1;
+              --base ${{ matrix.sdk.ref || 'main' }} 2>&1;
             echo $? >/tmp/exit.status
           ) |
           tee -a /tmp/pr-create-output.txt &&

--- a/.github/workflows/drop-pacman-package.yml
+++ b/.github/workflows/drop-pacman-package.yml
@@ -23,9 +23,20 @@ jobs:
   drop-pacman-package:
     strategy:
       matrix:
-        sdk: [git-sdk-64, git-sdk-arm64, git-sdk-32]
-    runs-on: ${{ matrix.sdk == 'git-sdk-arm64' && 'windows-11-arm' || 'windows-latest' }}
+        sdk:
+          - name: git-sdk-64
+            mingw-package-prefix: mingw-w64-x86_64
+          - name: git-sdk-arm64
+            mingw-package-prefix: mingw-w64-clang-aarch64
+          - name: git-sdk-32
+            mingw-package-prefix: mingw-w64-i686
+    runs-on: ${{ matrix.sdk.name == 'git-sdk-arm64' && 'windows-11-arm' || 'windows-latest' }}
     steps:
+      - name: Special-case MINGW packages
+        if: startsWith(env.PACKAGE, 'mingw-w64-')
+        shell: bash
+        run:
+          echo "PACKAGE=${{ matrix.sdk.mingw-package-prefix }}-${PACKAGE#mingw-w64-}" >>$GITHUB_ENV
       - name: obtain installation access token
         uses: actions/create-github-app-token@v3
         id: sdk-repo-token
@@ -33,12 +44,12 @@ jobs:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: ${{ matrix.sdk }}
-      - name: clone ${{ matrix.sdk }}
+          repositories: ${{ matrix.sdk.name }}
+      - name: clone ${{ matrix.sdk.name }}
         uses: actions/checkout@v6
         with:
           persist-credentials: true
-          repository: ${{ github.repository_owner }}/${{ matrix.sdk }}
+          repository: ${{ github.repository_owner }}/${{ matrix.sdk.name }}
           token: ${{ steps.sdk-repo-token.outputs.token }}
       - name: use the SDK's Bash and git.exe
         run: "usr\\bin\\bash.exe -lc 'cygpath -aw /usr/bin >>$GITHUB_PATH && cygpath -aw /cmd >>$GITHUB_PATH'"
@@ -64,7 +75,7 @@ jobs:
           git switch -c "$branch" &&
           git add -A . &&
           if git diff --cached --quiet; then
-            echo "::warning::${{ matrix.sdk }}: no changes to commit!"
+            echo "::warning::${{ matrix.sdk.name }}: no changes to commit!"
             exit 0
           fi &&
           commit_message="Drop package '$PACKAGE'

--- a/.github/workflows/drop-pacman-package.yml
+++ b/.github/workflows/drop-pacman-package.yml
@@ -1,4 +1,5 @@
-name: Drop Pacman package from SDKs
+name: Drop (uninstall) Pacman package from SDKs
+run-name: Drop (uninstall) Pacman package ${{ inputs.package }} from SDKs
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Previously, the workflow would only work for packages whose name is unchanged across Git for Windows SDKs, i.e. MSYS packages. However, MINGW packages' names start with a prefix that encodes the architecture. Let's support that via `mingw-w64-<name>`, which is auto-expanded to `${MINGW_PACKAGE_PREFIX}-<name>`.

While at it, also support UCRT64, which [is currently developed](https://github.com/git-for-windows/git-sdk-64/pull/117) on the `ucrt64` branch of git-sdk-64.