### PR TITLE
ensure-not-yet-deployed: drop stale Azure Blobs comment

### DIFF
--- a/update-scripts/ensure-not-yet-deployed.sh
+++ b/update-scripts/ensure-not-yet-deployed.sh
@@ -55,10 +55,6 @@ esac &&
 # correspond to the architecture. For i686/x86_64 MINGW packages (i.e. when
 # `--architecture` specifies an empty value), we assume that this script is run
 # in an x86_64 setup and therefore use that subdirectory.
-#
-# Note: The Pacman repository is hosted in an Azure Blobs container where
-# directory names cannot contain underscores, hence we needed to replace that
-# character with a dash.
 
 subdir="${architecture:-$arch}" &&
 case "$subdir" in


### PR DESCRIPTION
A leftover comment in `update-scripts/ensure-not-yet-deployed.sh` still claims that "the Pacman repository is hosted in an Azure Blobs container where directory names cannot contain underscores, hence we needed to replace that character with a dash." That note has been actively contradicted by the surrounding code ever since [7766f3c6](https://github.com/git-for-windows/git-for-windows-automation/commit/7766f3c6afa85af841439826560bf61e3219ad83) migrated the URL to `https://github.com/git-for-windows/pacman-repo/blob/$subdir/$file` and changed the rewrite from `any|x86_64) subdir=x86-64;;` to `any) subdir=x86_64;;` in the same commit, but forgot to delete this note.

Followup to the parallel fix in [gfw-helper-github-app#218](https://github.com/git-for-windows/gfw-helper-github-app/pull/218), which addresses [git-for-windows/git#6272 (comment)](https://github.com/git-for-windows/git/issues/6272#issuecomment-4671432007). The presence check here was already pointing at pacman-repo and works correctly; only the stale documentation needs to go.
