### PR TITLE
Support building and deploying UCRT64 packages

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -249,12 +249,12 @@ jobs:
           MINGW_ARCHS_TO_BUILD=$(
                     case "$ARCHITECTURE,$PACKAGE_TO_BUILD" in
                     aarch64,*) echo "clangarm64";;
-                    x86_64,*) echo "mingw64";;
+                    x86_64,*) echo "mingw64 ucrt64";;
                     i686,*) echo "mingw32";;
-                    ,mingw-w64-wintoast) echo "mingw32 mingw64 clangarm64";; # We're (cross-)compiling via Visual Studio
-                    ,mingw-w64-git-credential-manager) echo "mingw32 mingw64 clangarm64";; # We're downloading the pre-built artifacts for all three platforms
-                    ,mingw-w64-git-lfs) echo "mingw32 mingw64 clangarm64";; # We're downloading the pre-built artifacts from Git LFS' official release page
-                    ,*) echo "mingw32 mingw64";;
+                    ,mingw-w64-wintoast) echo "mingw32 mingw64 ucrt64 clangarm64";; # We're (cross-)compiling via Visual Studio
+                    ,mingw-w64-git-credential-manager) echo "mingw32 mingw64 ucrt64 clangarm64";; # We're downloading the pre-built artifacts for all three platforms
+                    ,mingw-w64-git-lfs) echo "mingw32 mingw64 ucrt64 clangarm64";; # We're downloading the pre-built artifacts from Git LFS' official release page
+                    ,*) echo "mingw32 mingw64 ucrt64";;
                     esac
           )
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -17,7 +17,7 @@ on:
         description: 'The ref containing the package definition'
         required: true
       architecture:
-        description: 'The architecture to build for (only for MSYS packages and all arm64 builds)'
+        description: 'The architecture to build for (only for MSYS packages, ucrt64 builds, and all arm64 builds)'
         required: false
       actor:
         description: The GitHub user on whose behalf this workflow is run
@@ -232,6 +232,10 @@ jobs:
               GIT_EXE="/mingw32/bin/git.exe"
               BUILD_SRC=
               ;;
+            ucrt64)
+              GIT_EXE="/ucrt64/bin/git.exe"
+              BUILD_SRC=
+              ;;
             *)
               GIT_EXE="/mingw64/bin/git.exe"
               BUILD_SRC="YesPlease"
@@ -251,6 +255,7 @@ jobs:
                     aarch64,*) echo "clangarm64";;
                     x86_64,*) echo "mingw64";;
                     i686,*) echo "mingw32";;
+                    ucrt64,*) echo "ucrt64";;
                     ,mingw-w64-wintoast) echo "mingw32 mingw64 clangarm64";; # We're (cross-)compiling via Visual Studio
                     ,mingw-w64-git-credential-manager) echo "mingw32 mingw64 clangarm64";; # We're downloading the pre-built artifacts for all three platforms
                     ,mingw-w64-git-lfs) echo "mingw32 mingw64 clangarm64";; # We're downloading the pre-built artifacts from Git LFS' official release page

--- a/update-scripts/ensure-not-yet-deployed.sh
+++ b/update-scripts/ensure-not-yet-deployed.sh
@@ -10,12 +10,11 @@ architecture=
 while case "$1" in
 --architecture=*)
 	architecture=${1#*=}
-	if test aarch64 = "$architecture"
-	then
-		MINGW_PACKAGE_PREFIX=mingw-w64-clang-aarch64
-	else
-		MINGW_PACKAGE_PREFIX=mingw-w64-$architecture
-	fi
+	case "$architecture" in
+	aarch64) MINGW_PACKAGE_PREFIX=mingw-w64-clang-aarch64;;
+	ucrt64)  MINGW_PACKAGE_PREFIX=mingw-w64-ucrt-x86_64;;
+	*)       MINGW_PACKAGE_PREFIX=mingw-w64-$architecture;;
+	esac
 	;;
 -*) die "Unhandled option: '$1'";;
 *) break;
@@ -26,6 +25,16 @@ die "Usage: $0 <directory-containing-PKGBUILD>"
 
 cd "$1" ||
 die "Could not switch to '$1'"
+
+# Some PKGBUILDs use $CARCH at top level (outside functions). Set it before
+# sourcing so that architecture-dependent logic (case statements, variable
+# assignments) works correctly even though we are not running under makepkg.
+case "$architecture" in
+aarch64)  CARCH=aarch64;;
+i686)     CARCH=i686;;
+*)        CARCH=x86_64;;
+esac &&
+export CARCH &&
 
 . ./PKGBUILD ||
 die "No/invalid PKGBUILD in '$1'?"
@@ -58,7 +67,7 @@ esac &&
 
 subdir="${architecture:-$arch}" &&
 case "$subdir" in
-any) subdir=x86_64;;
+any|ucrt64) subdir=x86_64;;
 esac &&
 
 case "$pkgname" in


### PR DESCRIPTION
This is part of the overall effort in git-for-windows/git-sdk-64#117, and it was used to deploy the UCRT64 variants of the Git for Windows-only MINGW packages to the Pacman repository.