### PR TITLE
git-artifacts: add support for UCRT64

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -76,6 +76,7 @@ jobs:
             exit 1
           }
 
+          set -x
           test -z "$TAG_GIT_WORKFLOW_RUN_ID" ||
           die 'existing_git_tag cannot be used with tag_git_workflow_run_id!'
 
@@ -87,9 +88,11 @@ jobs:
           mkdir -p bundle-artifacts &&
           echo "$EXISTING_GIT_TAG" >bundle-artifacts/next_version &&
           echo "$EXISTING_GIT_TAG" |
-          sed -n '/^v[0-9]\+\.[0-9]\+\.[0-9]\+\.windows\.[0-9]\+$/{s/^v//;s/\.windows\.1//;s/\.windows\.\(.*\)/(\1)/;p}' \
+          sed -n '/^v[0-9]\+\.[0-9]\+\.[0-9]\+\(-rc[0-9]\+\)\?\.windows\.[0-9]\+$/{s/^v//;s/\.windows\.1//;s/\.windows\.\(.*\)/(\1)/;p}' \
             >bundle-artifacts/display_version &&
           sed 's/(\(.*\))$/.\1/' <bundle-artifacts/display_version >bundle-artifacts/ver &&
+          ver="$(cat bundle-artifacts/ver)" &&
+          test -n "$ver" &&
           echo "GIT_VERSION=$EXISTING_GIT_TAG" >> $GITHUB_ENV &&
           git fetch --depth 1 --filter blob:none https://github.com/$OWNER/$REPO "refs/tags/$EXISTING_GIT_TAG:refs/tags/$EXISTING_GIT_TAG" &&
           echo "GIT_REV=$(git rev-parse --verify "refs/tags/$EXISTING_GIT_TAG"^0)" >>$GITHUB_ENV

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -15,6 +15,7 @@ on:
         - x86_64
         - i686
         - aarch64
+        - ucrt64
       tag_git_workflow_run_id:
         description: 'Workflow run ID of the tag-git pipeline'
         required: false
@@ -172,6 +173,12 @@ jobs:
               MINGW_PREFIX=/clangarm64
               MINGW_PACKAGE_PREFIX=mingw-w64-clang-aarch64
               SDK_REPO_ARCH=arm64
+              ;;
+            ucrt64)
+              MSYSTEM=UCRT64
+              MINGW_PREFIX=/ucrt64
+              MINGW_PACKAGE_PREFIX=mingw-w64-ucrt-x86_64
+              SDK_REPO_ARCH=64
               ;;
             *)
               echo "Unhandled architecture: $ARCHITECTURE"


### PR DESCRIPTION
In git-for-windows/git-sdk-64#117, a long-running PR, the UCRT64 flavor of Git for Windows' SDK is being established. Multiple packages have already been deployed, and now, in conjuction with https://github.com/git-for-windows/build-extra/pull/719, it is time to build installers.