### PR TITLE
upload-snapshot: include UCRT64 artifacts when present

### DIFF
--- a/.github/workflows/upload-snapshot.yml
+++ b/.github/workflows/upload-snapshot.yml
@@ -13,6 +13,9 @@ on:
       git_artifacts_aarch64_workflow_run_id:
         description: 'ID of the git-artifacts (aarch64) workflow run'
         required: true
+      git_artifacts_ucrt64_workflow_run_id:
+        description: 'ID of the git-artifacts (ucrt64) workflow run (optional; UCRT64 is only included in snapshots)'
+        required: false
 
 env:
   OWNER: "${{ github.repository_owner }}"
@@ -22,6 +25,7 @@ env:
   I686_WORKFLOW_RUN_ID: "${{ github.event.inputs.git_artifacts_i686_workflow_run_id }}"
   X86_64_WORKFLOW_RUN_ID: "${{ github.event.inputs.git_artifacts_x86_64_workflow_run_id }}"
   AARCH64_WORKFLOW_RUN_ID: "${{ github.event.inputs.git_artifacts_aarch64_workflow_run_id }}"
+  UCRT64_WORKFLOW_RUN_ID: "${{ github.event.inputs.git_artifacts_ucrt64_workflow_run_id }}"
   CREATE_CHECK_RUN: "true"
   NODEJS_VERSION: 16
 
@@ -105,10 +109,14 @@ jobs:
             } = require('./github-release')
 
             const token = ${{ toJSON(secrets.GITHUB_TOKEN) }}
-            const directories = ['bundle-artifacts-x86_64']
-            for (const arch of architectures) {
-              const architecture = arch.name
+            // UCRT64 is built only for snapshots, not for full releases. Pick
+            // it up leniently: only when a workflow run ID was provided, and
+            // only for the artifacts that are actually present in that run.
+            const architectureNames = architectures.map(arch => arch.name)
+            if (process.env.UCRT64_WORKFLOW_RUN_ID) architectureNames.push('ucrt64')
 
+            const directories = ['bundle-artifacts-x86_64']
+            for (const architecture of architectureNames) {
               const urls = architecture === 'x86_64'
                 ? ${{ steps.bundle-artifacts.outputs.x86_64-urls }}
                 : await getWorkflowRunArtifactsURLs(


### PR DESCRIPTION
Now that the git-artifacts workflow can build UCRT64 variants, this teaches `upload-snapshot.yml` to pick them up for the snapshots. UCRT64 is deliberately kept out of the full Git for Windows releases for the time being, so the pickup is lenient: a new optional `git_artifacts_ucrt64_workflow_run_id` input (with a matching `UCRT64_WORKFLOW_RUN_ID` environment variable) is honored only when it is provided, and even then only the UCRT64 artifacts that the run actually published are downloaded. A snapshot upload that runs against builds without UCRT64 (such as a full release, where this workflow picks up the bits that were produced) therefore contributes nothing extra.

The full-release path is left untouched: the `architectures` list in `github-release.js` that drives the release assembly keeps its three entries (`x86_64`, `i686`, `aarch64`), so full releases remain UCRT64-free.

Note that, to actually feed UCRT64 into the snapshots, whatever dispatches `upload-snapshot.yml` (the GitForWindowsHelper app) will need to pass the new `git_artifacts_ucrt64_workflow_run_id` input.
