### PR TITLE
Upgrade actions/checkout v6 to v7 in composite actions

### DIFF
--- a/.github/actions/gitforwindows.org/action.yml
+++ b/.github/actions/gitforwindows.org/action.yml
@@ -24,7 +24,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         ref: release
     - name: Mirror Check Run to ${{ inputs.owner }}/${{ inputs.repo }}

--- a/.github/actions/github-release/action.yml
+++ b/.github/actions/github-release/action.yml
@@ -55,7 +55,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         ref: release
     - name: Mirror Check Run to ${{ inputs.owner }}/${{ inputs.repo }}

--- a/.github/actions/mail-announcement/action.yml
+++ b/.github/actions/mail-announcement/action.yml
@@ -36,7 +36,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         ref: release
     - name: Mirror Check Run to ${{ inputs.owner }}/${{ inputs.repo }}

--- a/.github/actions/nuget-packages/action.yml
+++ b/.github/actions/nuget-packages/action.yml
@@ -36,7 +36,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         ref: release
     - name: Mirror Check Run to ${{ inputs.owner }}/${{ inputs.repo }}

--- a/.github/actions/pacman-packages/action.yml
+++ b/.github/actions/pacman-packages/action.yml
@@ -48,7 +48,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         ref: release
     - name: Mirror Check Run to ${{ inputs.owner }}/${{ inputs.repo }}

--- a/.github/actions/repository-updates/action.yml
+++ b/.github/actions/repository-updates/action.yml
@@ -33,7 +33,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         ref: release
     - name: Mirror Check Run to ${{ inputs.owner }}/${{ inputs.repo }}


### PR DESCRIPTION
I noticed during the -rc release engineering that there were still some warnings about an outdated Node version being required. The reason is that the composite actions under .github/actions/ still reference actions/checkout@v6, even though the workflow files were already bumped to v7 (via the dependabot run merged as #180, which touched only .github/workflows/). This commit brings the six composite actions (gitforwindows.org, github-release, mail-announcement, nuget-packages, pacman-packages, repository-updates) in line so the whole tree is consistent at v7.

Upgrading to checkout v7 requires no logic changes here. The v5 jump only raised the runtime to Node.js 24 (and the minimum Actions runner to v2.327.1, which the GitHub-hosted runners already satisfy). v6 persists the checkout credential to a separate file rather than into .git/config, which is transparent to these composite actions since none of them parse .git/config for that token. v7 refuses to check out fork pull requests under the pull_request_target and workflow_run triggers, neither of which is used anywhere in this repository.