### PR TITLE
pacman-packages: deploy UCRT64 packages, too, if available

### DIFF
--- a/.github/actions/pacman-packages/action.yml
+++ b/.github/actions/pacman-packages/action.yml
@@ -36,6 +36,9 @@ inputs:
   git_artifacts_aarch64_workflow_run_id:
     description: 'ID of the git-artifacts (aarch64) workflow run'
     required: true
+  git_artifacts_ucrt64_workflow_run_id:
+    description: 'ID of the git-artifacts (ucrt64) workflow run (optional; UCRT64 is only included when it was built)'
+    required: false
   gpg-key:
     description: 'The GPG key to use to sign the updated Pacman database'
     required: true
@@ -61,7 +64,7 @@ runs:
         rev: ${{ inputs.rev }}
         check-run-name: "pacman-packages"
         title: "Deploy the mingw-w64-git packages ${{ inputs.display-version }}"
-        summary: "Downloading the Pacman packages from ${{ inputs.git_artifacts_x86_64_workflow_run_id }}, ${{ inputs.git_artifacts_i686_workflow_run_id }}, and ${{ inputs.git_artifacts_aarch64_workflow_run_id }} and deploying them to the Pacman Repository"
+        summary: "Downloading the Pacman packages from ${{ inputs.git_artifacts_x86_64_workflow_run_id }}, ${{ inputs.git_artifacts_i686_workflow_run_id }}, and ${{ inputs.git_artifacts_aarch64_workflow_run_id }}${{ inputs.git_artifacts_ucrt64_workflow_run_id && format(' (and UCRT64 from {0})', inputs.git_artifacts_ucrt64_workflow_run_id) || '' }} and deploying them to the Pacman Repository"
         text: "For details, see [this run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}})."
         details-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}}"
     - name: Download artifacts
@@ -95,6 +98,17 @@ runs:
             artifactsRepo,
             ${{ inputs.git_artifacts_aarch64_workflow_run_id }},
             'pkg-aarch64'
+          )
+
+          // Include the UCRT64 packages when a run ID was provided
+          const ucrt64WorkflowRunId = '${{ inputs.git_artifacts_ucrt64_workflow_run_id }}'
+          if (ucrt64WorkflowRunId) await getWorkflowRunArtifact(
+            console,
+            ${{ toJSON(inputs.artifacts-token) }},
+            artifactsOwner,
+            artifactsRepo,
+            ucrt64WorkflowRunId,
+            'pkg-ucrt64'
           )
     - name: Download Git for Windows SDK
       uses: git-for-windows/setup-git-for-windows-sdk@v2
@@ -137,7 +151,12 @@ runs:
         azure_blobs_token: ${{ inputs.azure-blobs-token }}
         GITHUB_TOKEN: ${{ steps.pacman-repo-token.outputs.token }}
       run: |
-        "$RUNNER_TEMP"/build-extra/pacman-helper.sh quick_add pkg-x86_64/*.tar.* pkg-i686/*.tar.* pkg-aarch64/*.tar.*
+        set -- pkg-x86_64/*.tar.* pkg-i686/*.tar.* pkg-aarch64/*.tar.*
+        if test -n '${{ inputs.git_artifacts_ucrt64_workflow_run_id }}'
+        then
+          set -- "$@" pkg-ucrt64/*.tar.*
+        fi
+        "$RUNNER_TEMP"/build-extra/pacman-helper.sh quick_add "$@"
     - name: update check-run
       if: always()
       uses: ./.github/actions/check-run-action

--- a/.github/workflows/release-git.yml
+++ b/.github/workflows/release-git.yml
@@ -12,6 +12,9 @@ on:
       git_artifacts_aarch64_workflow_run_id:
         description: 'ID of the git-artifacts (aarch64) workflow run'
         required: true
+      git_artifacts_ucrt64_workflow_run_id:
+        description: 'ID of the git-artifacts (ucrt64) workflow run (optional; auto-detected from the tagged commit''s check-runs if omitted)'
+        required: false
 
 env:
   HOME: "${{github.workspace}}\\home"
@@ -21,6 +24,7 @@ env:
   I686_WORKFLOW_RUN_ID: "${{github.event.inputs.git_artifacts_i686_workflow_run_id}}"
   X86_64_WORKFLOW_RUN_ID: "${{github.event.inputs.git_artifacts_x86_64_workflow_run_id}}"
   AARCH64_WORKFLOW_RUN_ID: "${{github.event.inputs.git_artifacts_aarch64_workflow_run_id}}"
+  UCRT64_WORKFLOW_RUN_ID: "${{github.event.inputs.git_artifacts_ucrt64_workflow_run_id}}"
 
 jobs:
   setup:
@@ -32,6 +36,7 @@ jobs:
       ver: ${{ steps.bundle-artifacts.outputs.ver }}
       git-rev: ${{ steps.bundle-artifacts.outputs.git-rev }}
       release-notes: ${{ steps.bundle-artifacts.outputs.release-notes }}
+      ucrt64-workflow-run-id: ${{ steps.ucrt64.outputs.workflow-run-id }}
       pull-request-number: ${{ steps.announcement.outputs.pull-request-number }}
       pull-request-comment: ${{ steps.announcement.outputs.pull-request-comment }}
     steps:
@@ -106,6 +111,24 @@ jobs:
             core.endGroup()
 
             core.setOutput('release-notes', result.releaseNotes)
+      - name: Look for a UCRT64 git-artifacts run
+        id: ucrt64
+        uses: actions/github-script@v9
+        with:
+          script: |
+            // Honor an explicit override, otherwise discover the run.
+            let workflowRunId = process.env.UCRT64_WORKFLOW_RUN_ID
+            if (!workflowRunId) {
+              const findUCRT64GitArtifactsRun = require('./find-ucrt64-git-artifacts-run')
+              workflowRunId = await findUCRT64GitArtifactsRun(
+                console,
+                '${{ secrets.GITHUB_TOKEN }}',
+                process.env.OWNER,
+                process.env.REPO,
+                ${{ toJSON(steps.bundle-artifacts.outputs.git-rev) }}
+              )
+            }
+            core.setOutput('workflow-run-id', workflowRunId || '')
       - name: Re-publish bundle-artifacts so the next job can easily use it
         uses: actions/upload-artifact@v7
         with:
@@ -238,6 +261,7 @@ jobs:
           git_artifacts_i686_workflow_run_id: ${{ env.I686_WORKFLOW_RUN_ID }}
           git_artifacts_x86_64_workflow_run_id: ${{ env.X86_64_WORKFLOW_RUN_ID }}
           git_artifacts_aarch64_workflow_run_id: ${{ env.AARCH64_WORKFLOW_RUN_ID }}
+          git_artifacts_ucrt64_workflow_run_id: ${{ needs.setup.outputs.ucrt64-workflow-run-id }}
           gpg-key: ${{ secrets.GPGKEY }}
           priv-gpg-key: ${{ secrets.PRIVGPGKEY }}
           azure-blobs-token: ${{ secrets.AZURE_BLOBS_TOKEN }}

--- a/find-ucrt64-git-artifacts-run.js
+++ b/find-ucrt64-git-artifacts-run.js
@@ -1,0 +1,52 @@
+// Locate the git-artifacts run for the UCRT64 variant that is built alongside
+// MINGW64 during the migration, and that will replace it as the official Intel
+// 64-bit build (returning '' while no such transitional run exists yet).
+
+const findUCRT64GitArtifactsRun = async (context, token, owner, repo, sha) => {
+  const githubApiRequest = require('./github-api-request')
+
+  // The git-artifacts workflow mirrors a `git-artifacts-ucrt64` check-run onto
+  // the tagged commit in git-for-windows/git, whose details URL points back at
+  // the run in the git-for-windows-automation repository.
+  const { check_runs } = await githubApiRequest(
+    context,
+    token,
+    'GET',
+    `/repos/${owner}/${repo}/commits/${sha}/check-runs?check_name=git-artifacts-ucrt64`
+  )
+
+  // Prefer the most recently started successful run, falling back to the most
+  // recent run of any conclusion (e.g. while it is still in progress).
+  const candidates = check_runs
+    .filter(c => /\/actions\/runs\/\d+/.test(c.details_url || ''))
+    .sort((a, b) => Date.parse(b.started_at || 0) - Date.parse(a.started_at || 0))
+  const match = candidates.find(c => c.conclusion === 'success') || candidates[0]
+  if (!match) {
+    context.log(`No UCRT64 git-artifacts run found for ${owner}/${repo}@${sha}`)
+    return ''
+  }
+
+  const runId = match.details_url.match(/\/actions\/runs\/(\d+)/)[1]
+  context.log(`Found UCRT64 git-artifacts run ${runId} (check-run ${match.id}, conclusion: ${match.conclusion || 'pending'})`)
+  return runId
+}
+
+module.exports = findUCRT64GitArtifactsRun
+
+if (require.main === module) {
+  const [owner, repo, sha] = process.argv.slice(2)
+  if (!owner || !repo || !sha) {
+    console.error(`Usage: ${process.argv[1]} <owner> <repo> <commit-ish>`)
+    process.exit(1)
+  }
+
+  const token = process.env.GITHUB_TOKEN
+  if (!token) {
+    console.error('Need GITHUB_TOKEN in the environment')
+    process.exit(1)
+  }
+
+  findUCRT64GitArtifactsRun(console, token, owner, repo, sha)
+    .then(runId => process.stdout.write(`${runId}\n`))
+    .catch(err => { console.error(err); process.exit(1) })
+}


### PR DESCRIPTION
Git for Windows is in the middle of migrating from MINGW64 to UCRT64 (see https://github.com/git-for-windows/git-sdk-64/pull/117 for full details).

For the time being, `git-artifacts` _does_ build the UCRT64 variants of installers, portable Gits, etc, using the `-ucrt64` file name infix to indicate this flavor. These are _not_ published with the official releases, even though they are part of the snapshots.

To allow for efficient testing and developing of the UCR64 side of Git for Windows, let's also deploy the corresponding Pacman packages (which will eventually back the regular `-64-bit` artifacts, once the migration to UCRT64 is complete.