### PR TITLE
Allow for more clock drift when generating the JWT

### DIFF
--- a/github-api-request-as-app.js
+++ b/github-api-request-as-app.js
@@ -9,8 +9,8 @@ module.exports = async (context, appId, privateKey, requestMethod, requestPath, 
     const payload = {
         // issued at time, 60 seconds in the past to allow for clock drift
         iat: now - 60,
-        // JWT expiration time (10 minute maximum)
-        exp: now + (10 * 60),
+        // JWT expiration time (10 minute maximum, use 9 to allow for clock drift)
+        exp: now + (9 * 60),
         // GitHub App's identifier
         iss: appId
     }


### PR DESCRIPTION
A recent `git-artifacts` run failed in its `artifacts` job at the `update-check-run` step and only recovered after two manual re-runs, see https://github.com/git-for-windows/git-for-windows-automation/actions/runs/28040536039/job/83019154625. GitHub's API returned 401 with `{"message":"'Expiration time' claim ('exp') is too far in the future", ...}`.

The cause is that `github-api-request-as-app.js` signs the GitHub App JWT with `exp` set to `now + 10 * 60`, i.e. exactly the 10-minute ceiling GitHub permits. Whenever the runner's wall clock drifts even slightly ahead of GitHub's, the claim lands past the accepted horizon and the request is rejected outright.

The sibling repository `gfw-helper-github-app` hit the identical symptom and fixed it in November 2023 by backing the expiry off to 9 minutes, see https://github.com/git-for-windows/gfw-helper-github-app/commit/ebb4adab0e379159a47cbac01457cb3ed0caeec8. The corresponding file here was added in 92d02f1a and never picked up that fix, so this PR ports it verbatim. The change is two lines and has been running cleanly in the sibling for over two years.
