### PR TITLE
Enable the `mingit-busybox` artifact for `aarch64`

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -196,9 +196,8 @@ jobs:
           echo "MINGW_PACKAGE_PREFIX=$MINGW_PACKAGE_PREFIX" >> $GITHUB_OUTPUT
           echo "SDK_REPO_ARCH=$SDK_REPO_ARCH" >> $GITHUB_OUTPUT
           test -n "$ARTIFACTS_TO_BUILD" || {
-            ARTIFACTS_TO_BUILD="mingit"
+            ARTIFACTS_TO_BUILD="mingit mingit-busybox"
             test "$ARCHITECTURE" = i686 || ARTIFACTS_TO_BUILD="installer portable archive $ARTIFACTS_TO_BUILD"
-            test "$ARCHITECTURE" = aarch64 || ARTIFACTS_TO_BUILD="$ARTIFACTS_TO_BUILD mingit-busybox"
             test "$ARCHITECTURE" != x86_64 || ARTIFACTS_TO_BUILD="$ARTIFACTS_TO_BUILD nuget"
           }
           echo "ARTIFACTS_TO_BUILD=$ARTIFACTS_TO_BUILD" >> $GITHUB_ENV

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ Similarly, package-specific checksum update scripts in `update-scripts/checksums
 Git for Windows builds for three architectures:
 - `x86_64` (64-bit) - Full support: installer, portable, archive, MinGit, NuGet
 - `i686` (32-bit) - MinGit only
-- `aarch64` (ARM64) - All artifacts except MinGit-BusyBox
+- `aarch64` (ARM64) - All artifacts except NuGet
 
 ## Relationship with Other Repositories
 

--- a/create-artifacts-matrix.js
+++ b/create-artifacts-matrix.js
@@ -29,7 +29,7 @@ module.exports = (artifactsString, architecture) => {
         fileExtension: 'tar.bz2'
     })
 
-    if (architecture !== 'aarch64') validArtifacts.push({
+    validArtifacts.push({
         name: 'mingit-busybox',
         filePrefix: 'MinGit',
         fileExtension: 'zip'

--- a/github-release.js
+++ b/github-release.js
@@ -208,7 +208,6 @@ const getGitArtifacts = async (
 
     const urls = await getWorkflowRunArtifactsURLs(context, token, owner, repo, workflowRunId)
     for (const artifact of artifacts) {
-      if (architecture.name === 'aarch64' && artifact.name === 'mingit-busybox') continue
       if (architecture.name === 'i686' && !artifact.name.startsWith('mingit')) continue
       const name = `${artifact.name}-${architecture.name}`
       context.log(`Downloading ${name}`)


### PR DESCRIPTION
`mingit-busybox` was omitted for `aarch64` because there was no ARM64 BusyBox-w32 build.

`mingw-w64-clang-aarch64-busybox` is now built and deployed to the pacman repository by [Build and deploy mingw-w64-busybox (aarch64)](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/28293304291), which published the [ARM64 busybox package](https://github.com/git-for-windows/pacman-repo/blob/33769bc14838c96b99fb67e2496ca94a7b299a0f/mingw-w64-clang-aarch64-busybox-1.38.0.21234.d8d8bb397-1-any.pkg.tar.xz).
The first version was published in the pacman repo on [2026-06-05](https://github.com/git-for-windows/pacman-repo/commit/81640d49262f014ad0bbcc769b537a53259dc9fd).

**Prerequisite**: the package needs to be installed into `git-sdk-arm64` (as done for `git-sdk-64` in git-for-windows/git-sdk-64@24267af8ac).

`AGENTS.md` : The `aarch64` line of `Supported Architectures` changes from `All artifacts except MinGit-BusyBox` to `All artifacts except NuGet`. `aarch64` has never built NuGet (x86_64-only), so with BusyBox no longer excluded, NuGet is the only remaining exception.

Issue: https://github.com/git-for-windows/git/issues/3107