### PR TITLE
open pr: support InnoSetup 7

### DIFF
--- a/update-scripts/version/innosetup
+++ b/update-scripts/version/innosetup
@@ -2,10 +2,12 @@
 
 set -x &&
 version_underscores="$(echo "$1" | tr . _)" &&
-url="https://github.com/jrsoftware/issrc/releases/download/is-$version_underscores/innosetup-$1.exe" &&
+url="https://github.com/jrsoftware/issrc/releases/download" &&
+url="$url/is-$version_underscores/innosetup-$1-x64.exe" &&
 curl -# -LR -D curl.log -o is.exe "$url" &&
 cat curl.log &&
 grep 'HTTP/.* 200' curl.log &&
+rm -r InnoSetup/ &&
 ./is.exe //verysilent //dir=InnoSetup //noicons //tasks= //portable=1 //lang=english \
   //SP- //SUPPRESSMSGBOXES //NORESTART //LOG=is.log &&
 cat is.log &&


### PR DESCRIPTION
The failed [`/open pr` run](https://github.com/git-for-windows/git/issues/6320#issuecomment-4959941064) requested the old unsuffixed `innosetup-7.0.2.exe` and received HTTP 404. Inno Setup 7.0.2 [publishes separate x64 and x86 assets](https://github.com/jrsoftware/issrc/releases/tag/is-7_0_2), and the [discussion landed on x64](https://github.com/git-for-windows/git/issues/6320#issuecomment-4960049027).

This PR requires https://github.com/git-for-windows/build-extra/pull/725 to be merged first, and both are needed to address https://github.com/git-for-windows/git/issues/6320.
